### PR TITLE
Implement phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# dbz-octgn-patch

--- a/definition.xml
+++ b/definition.xml
@@ -113,6 +113,8 @@
     <group name="Discard Pile" visibility="all" icon="groups/graveyard.png" shortcut="F6">
     <groupaction menu="Banish top card" default="True" shortcut="Ctrl+B" execute="banishTop" />
     <groupaction menu="Banish bottom card" default="True" shortcut="Ctrl+Shift+B" execute="banishBottom" />
+    <groupaction menu="Rejuvenate 1" default="True" shortcut="F5" execute="rejuvenateOne" />
+    <groupaction menu="Rejuvenate X..." default="True" shortcut="F6" execute="rejuvenateMany" />
 </group>
     <group name="Removed from game" visibility="all" icon="groups/removed.png" collapsed="False" shortcut="F7"></group>
 	<group name="Starting" visibility="none" icon="groups/starting.png" collapsed="False" shortcut="F8"></group>

--- a/definition.xml
+++ b/definition.xml
@@ -17,22 +17,35 @@
 <script src="scripts/actions.py" />
 <script src="scripts/generic.py" />
 <script src="scripts/constants.py" />
+<script src="scripts/engine.py" />
 <script src="scripts/events.py" />
 <script src="scripts/plugin.py" />
 <script src="scripts/util.py" />
 </scripts>
 <events>
-   <event name="OnLoadDeck" action="loadDeck" />
+   <event name="OnGameStarted" action="gameInit" />
+   <event name="OnDeckLoaded" action="loadDeck" />
    <event name="OnTurnPassed" action="autosave" />
+   <event name="OnPhasePassed" action="handlePhase" />
 </events>
 <fonts>
 </fonts>
 <proxygen definitionsrc="proxy/proxydef.xml">
 </proxygen>
+<phases>
+  <phase name="Draw Step" icon="groups/sideboard.png" />
+  <phase name="Planning Step" icon="groups/sideboard.png" />
+  <phase name="Declare Step" icon="groups/sideboard.png" />
+  <phase name="Entering Combat" icon="groups/sideboard.png" />
+  <phase name="Combat Step" icon="groups/sideboard.png" />
+  <phase name="Discard Step" icon="groups/sideboard.png" />
+  <phase name="Rejuvenation Step" icon="groups/sideboard.png" />
+</phases>
 <documents>
       <document name="Turn Sequence/Attack Table" icon="documents/Manual.png" src="documents/reference.png" />
 </documents>
 <globalvariables>
+   <globalvariable name="numLoadedDecks" value="0" />
 </globalvariables>
 <card back="Cards/back.png" front="Cards/front.png" width="63" height="88">
 	<property name="Style" type="String" />
@@ -45,8 +58,7 @@
 	<property name="PUR" type="String" />
 	<property name="Power Rating" type="String" />
     <property name="Rarity" type="String" />
-<property name="Card Level" type="String" />
-
+    <property name="Card Level" type="String" />
 </card>
 <table name="Table" visibility="undefined" ordered="False" width="500" height="380" background="Board/background.png" backgroundStyle="uniformToFill">
    <groupaction menu="Clear all" shortcut="F4" execute="untapAll" />
@@ -54,6 +66,7 @@
    <groupaction menu="Roll a die" shortcut="Ctrl+R" execute="roll20" />
    <groupaction menu="Flip a coin" shortcut="Ctrl+F" execute="flipCoin" />
    <groupaction menu="Power up Personalities" shortcut="Ctrl+P" execute="powerUp" />
+   <!--groupaction menu="Show AT Value" shortcut="Ctrl+A" execute="lookupAttackTable" /-->
    <cardaction menu="Use Card" default="True" execute="useCard"/>
    <cardaction menu="Flip Up/Down" execute="flip" />
    <cardaction menu="Discard" shortcut="Del" execute="discard" />
@@ -61,13 +74,6 @@
    <cardaction menu="Lower Power Stage" shortcut="F2" execute="removeCounter" />
 	<cardaction menu="Set Power Stage" shortcut="F3" execute="setCounter" />
    <groupaction menu="Move to Next phase." default="False" shortcut="Ctrl+Enter" execute="nextPhase" />
-   <groupactions menu="Phases...">
-      <groupaction menu="Jump to Draw Step." default="False" shortcut="F5" execute="goToDraw" />
-      <groupaction menu="Jump to Planning Step." default="False" shortcut="F6" execute="goToPlanning" />
-      <groupaction menu="Jump to Declare Combat." default="False" shortcut="F7" execute="goToDeclare" />
-      <groupaction menu="Jump to Combat Step." default="False" shortcut="F8" execute="goToCombat" />
-      <groupaction menu="Jump to Rejuvenation Step." default="False" shortcut="F9" execute="goToRejuv" />
-   </groupactions>
    <groupactions menu="Announcements">
       <groupaction menu="OK" default="False" execute="BUTTON_OK"  shortcut="Ctrl+1"/>
       <groupaction menu="Wait!" default="False" execute="BUTTON_Wait" shortcut="Ctrl+2"/>
@@ -82,7 +88,9 @@
 		</groupactions>
 </table>
 <player summary="Anger: {#Anger} / Hand: {#Hand}">
-   <globalvariable name="phase" value="0" /> 
+   <globalvariable name="powerLevel" value="0" />
+   <globalvariable name="combatDeclared" value="False" />
+   <globalvariable name="maxHandSize" value="1" />
 	<counter name="Anger" icon="Counters/anger.png" default="0" />
 	<hand name="Hand" visibility="me" ordered="False" icon="groups/hand.png">
 	<cardaction menu="Play Card" default="True" execute="play" />

--- a/definition.xml
+++ b/definition.xml
@@ -23,6 +23,7 @@
 <script src="scripts/util.py" />
 </scripts>
 <events>
+   <event name="OnTableLoaded" action="boardInit" />
    <event name="OnGameStarted" action="gameInit" />
    <event name="OnDeckLoaded" action="loadDeck" />
    <event name="OnTurnPassed" action="autosave" />
@@ -45,6 +46,7 @@
       <document name="Turn Sequence/Attack Table" icon="documents/Manual.png" src="documents/reference.png" />
 </documents>
 <globalvariables>
+   <globalvariable name="automationEnabled" value="False" />
    <globalvariable name="numLoadedDecks" value="0" />
 </globalvariables>
 <card back="Cards/back.png" front="Cards/front.png" width="63" height="88">
@@ -74,18 +76,22 @@
    <cardaction menu="Lower Power Stage" shortcut="F2" execute="removeCounter" />
 	<cardaction menu="Set Power Stage" shortcut="F3" execute="setCounter" />
    <groupaction menu="Move to Next phase." default="False" shortcut="Ctrl+Enter" execute="nextPhase" />
+   <groupactions menu="Game Setup Automation">
+      <groupaction menu="Enable Automation" shortcut="Ctrl+A" execute="enableSetupAutomation" />
+      <groupaction menu="Disable Automation" shortcut="Ctrl+Z" execute="disableSetupAutomation" />
+   </groupactions>
    <groupactions menu="Announcements">
       <groupaction menu="OK" default="False" execute="BUTTON_OK"  shortcut="Ctrl+1"/>
       <groupaction menu="Wait!" default="False" execute="BUTTON_Wait" shortcut="Ctrl+2"/>
       <groupaction menu="Actions?" default="False" execute="BUTTON_Actions" shortcut="Ctrl+3"/>
       <groupaction menu="Pass." default="False" execute="declarePass" shortcut="Ctrl+Space"/>
    </groupactions>
-	<groupactions menu="Saving Tools">
+   <groupactions menu="Saving Tools">
 		<groupaction menu="Save Game..." default="False" execute="saveTable" />
 		<groupaction menu="Load Game..." default="False" execute="loadTable" />
 		<groupaction menu="Autosave Mode On..." default="False" execute="autosaveOn" />
 		<groupaction menu="Autosave Mode Off..." default="False" execute="autosaveOff" />
-		</groupactions>
+   </groupactions>
 </table>
 <player summary="Anger: {#Anger} / Hand: {#Hand}">
    <globalvariable name="powerLevel" value="0" />

--- a/scripts/actions.py
+++ b/scripts/actions.py
@@ -1,5 +1,11 @@
-import re
 ####################################################
+#  actions.py
+# This script contains functions that are invoked
+# directly by the player. For example, menu options
+# double clicking cards,and hotkeys
+####################################################
+
+import re
 
 def untapAll(group, x = 0, y = 0):
 	mute()
@@ -158,6 +164,26 @@ def shuffle(group):
 # Phases
 #---------------------------------------------------------------------------
 
+# nextPhase
+# Invoked by the Active Player by pressing Ctrl+Enter
+# Increments the phase counter using setPhase
+# Exceptions:
+#  - If the current phase is the final phase of the turn,
+#    pass the turn to the opponent
+#  - TODO: If the current phase is the discard step and
+#    players have too many cards in hand, do not allow
+#    progression to the next phase
+def nextPhase(group = table, x = 0, y = 0): 
+   mute()
+   phase = currentPhase()
+   #if phase[1] == 6 and not enforceHandLimits():
+       #return
+   if phase[1] == 7: 
+      nextTurn(findOpponent())
+      return  
+   else:
+    setPhase(phase[1]+1)
+
 def showCurrentPhase(phaseNR = None): # Just say a nice notification about which phase you're on.
    if phaseNR: notify(phases[phaseNR])
    else: notify(phases[num(me.getGlobalVariable('phase'))])
@@ -167,6 +193,18 @@ def endMyTurn(opponent = None):
    me.setGlobalVariable('phase','0') # In case we're on the last phase (Force), we end our turn.
    notify("=== {} has ended their turn ===.".format(me))
    opponent.setActivePlayer() 
+
+#---------------------------------------------------------------------------
+# Automation Management Functions
+#---------------------------------------------------------------------------
+
+def enableSetupAutomation(group = table, x = 0, y = 0):
+    setGlobalVariable("automationEnabled", "True")
+    notify("Game Setup Automation enabled for both players.")
+
+def disableSetupAutomation(group = table, x = 0, y = 0):
+    setGlobalVariable("automationEnabled", "False")
+    notify("Game Setup Automation disabled for both players.")
 
 #---------------------------------------------------------------------------
 # Meta Functions

--- a/scripts/actions.py
+++ b/scripts/actions.py
@@ -146,6 +146,15 @@ def drawMany(group, count = None):
 	for card in group.top(count): card.moveTo(me.hand)
 	notify("{} draws {} cards.".format(me, count))
 
+def rejuvenateOne(group):
+    rejuvenate()
+
+def rejuvenateMany(group):
+    if len(group) == 0: return
+    count = askInteger("Rejuvenate how many cards?", 0)
+    if count > 0:
+        rejuvenate(count)
+
 def drawThree():
     mute()
     for card in me.piles["Life Deck"].top(3): card.moveTo(me.hand)

--- a/scripts/actions.py
+++ b/scripts/actions.py
@@ -39,6 +39,7 @@ def powerUp(group, x = 0, y = 0):
                                         card.markers[CounterMarker] = 10
                         except:
                                 pass
+        notify("{} powers up their personalities".format(me.name))
 
 def tap(card, x = 0, y = 0):
     mute()
@@ -56,6 +57,12 @@ def flip(card, x = 0, y = 0):
     else:
         card.isFaceUp = True
         notify("{} turns {} face up.".format(me, card))
+
+def faceUpAll():
+    mute()
+    for c in table:
+        if c.controller == me:
+            c.isFaceUp = True
 
 def discard(card, x = 0, y = 0):
 	card.moveTo(me.piles['Discard Pile'])
@@ -88,10 +95,16 @@ def setCounter(card, x = 0, y = 0):
 	card.markers[CounterMarker] = quantity	
 		
 def play(card, x = 0, y = 0):
-	mute()
-	src = card.group
-	card.moveToTable(0, 0)
-	notify("{} plays {} from their {}.".format(me, card, src.name))
+    mute()
+    src = card.group
+    if not me.isInverted:
+        cardPlayed_x_offset = HostPlayerCardPlayed_x_Offset
+        cardPlayed_y_offset = HostPlayerCardPlayed_y_Offset
+    else:
+        cardPlayed_x_offset = GuestPlayerCardPlayed_x_Offset
+        cardPlayed_y_offset = GuestPlayerCardPlayed_y_Offset
+    card.moveToTable(cardPlayed_x_offset, cardPlayed_y_offset)
+    notify("{} plays {} from their {}.".format(me, card, src.name))
 
 def mulligan(group):
     mute()
@@ -127,6 +140,11 @@ def drawMany(group, count = None):
 	for card in group.top(count): card.moveTo(me.hand)
 	notify("{} draws {} cards.".format(me, count))
 
+def drawThree():
+    mute()
+    for card in me.piles["Life Deck"].top(3): card.moveTo(me.hand)
+    notify("{} draws 3 cards.".format(me))
+
 def drawBottom(group, x = 0, y = 0):
 	if len(group) == 0: return
 	mute()
@@ -149,50 +167,6 @@ def endMyTurn(opponent = None):
    me.setGlobalVariable('phase','0') # In case we're on the last phase (Force), we end our turn.
    notify("=== {} has ended their turn ===.".format(me))
    opponent.setActivePlayer() 
-      
-def nextPhase(group = table, x = 0, y = 0, setTo = None):  
-# Function to take you to the next phase. 
-   mute()
-   phase = num(me.getGlobalVariable('phase'))
-   if phase == 5: 
-      endMyTurn()
-      return  
-   else:
-      if not me.isActivePlayer and confirm("Your opponent does not seem to have ended their turn yet. Switch to your turn?"):
-         remoteCall(findOpponent(),'endMyTurn',[me])
-         rnd(1,1000) # Pause to wait until they change their turn
-      phase += 1
-      if phase == 1: goToDraw()
-      elif phase == 2: goToPlanning()
-      elif phase == 3: goToDeclare()
-      elif phase == 4: goToCombat()
-      elif phase == 5: goToRejuv()
-
-def goToDraw(group = table, x = 0, y = 0): # Go directly to the Balance phase
-   mute()
-   me.setGlobalVariable('phase','1')
-   showCurrentPhase(1)
-         
-def goToPlanning(group = table, x = 0, y = 0): # Go directly to the Balance phase
-   mute()
-   me.setGlobalVariable('phase','2')
-   showCurrentPhase(2)
-         
-def goToDeclare(group = table, x = 0, y = 0): # Go directly to the Balance phase
-   mute()
-   me.setGlobalVariable('phase','3')
-   showCurrentPhase(3)
-         
-def goToCombat(group = table, x = 0, y = 0): # Go directly to the Balance phase
-   mute()
-   me.setGlobalVariable('phase','4')
-   showCurrentPhase(4)
-         
-def goToRejuv(group = table, x = 0, y = 0): # Go directly to the Balance phase
-   mute()
-   me.setGlobalVariable('phase','5')
-   showCurrentPhase(5)
-         
 
 #---------------------------------------------------------------------------
 # Meta Functions

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,3 +1,8 @@
+####################################################
+#  constants.py
+# This script contains constant definitions
+####################################################
+
 CounterMarker =("Power Stage", "d766faa2-b28a-4fca-86c2-b752c0293714")
 
 HostPlayerMP_x_Offset = 0

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,9 +1,15 @@
-phases = [
-    "Opponent's Turn",
-    "=== Draw Step ===",
-    "=== Planning Step ===",
-    "=== Declare Combat ===",
-    "=== Combat Step ===",
-    "=== Rejuvenation Step ==="]
-
 CounterMarker =("Power Stage", "d766faa2-b28a-4fca-86c2-b752c0293714")
+
+HostPlayerMP_x_Offset = 0
+HostPlayerMP_y_Offset = 12
+HostPlayerMastery_x_Offset = 80
+HostPlayerMastery_y_Offset = 12
+HostPlayerCardPlayed_x_Offset = 160
+HostPlayerCardPlayed_y_Offset = 12
+
+GuestPlayerMP_x_Offset = 80
+GuestPlayerMP_y_Offset = -100
+GuestPlayerMastery_x_Offset = 0
+GuestPlayerMastery_y_Offset = -100
+GuestPlayerCardPlayed_x_Offset = -80
+GuestPlayerCardPlayed_y_Offset = -100

--- a/scripts/engine.py
+++ b/scripts/engine.py
@@ -1,0 +1,187 @@
+import re
+
+# ===================
+# Game Intialization
+# ===================
+
+# gameSetup 
+# This function prepares the game for the first turn.
+# It should be called by both players.
+# Invokes 'faceUpAll' to turn MP/Mastery face up.
+# Shuffles the player's Life Deck
+# Searches the table for the player's MP and sets its
+# power stage to 5 above 0.
+def gameSetup():
+    faceUpAll()
+    me.piles["Life Deck"].shuffle()
+    for c in table:
+        if c.controller == me and c.properties["Card Level"] is not "":
+            c.markers[CounterMarker] = 5
+
+# determineFirstPlayer
+# This function should be called by only one player.
+# Randomly determine which player will have the option
+# of going first, and present the choice to that player.
+# TODO: Add "Before the first turn" effects (Currently
+# just Saiyan Dynamic Mastery)
+def determineFirstPlayer():
+    n = rnd(0, 1)
+    notify("OCTGN randomly determined {} will choose which player takes the first turn".format(players[n]))
+    if players[n] == me:
+        chooseFirstPlayer()
+    else:
+        remoteCall(findOpponent(), "chooseFirstPlayer", [])
+
+# chooseFirstPlayer
+# Only called by determineFirstPlayer
+# Manages the choice for which player takes the first
+# turn and sets the Active Player appropriately
+def chooseFirstPlayer():
+    choices = [me.name, findOpponent().name]
+    choice = askChoice("Choose first player", choices)
+    if choice == 2:
+        setActivePlayer(findOpponent())
+    else:
+        setActivePlayer(me)
+
+# ==========================
+# End Game Initialization
+# ==========================
+
+
+# =================
+# Phase Management
+# =================
+
+# nextPhase
+# Invoked by the Active Player by pressing Ctrl+Enter
+# Increments the phase counter using setPhase
+# Exceptions:
+#  - If the current phase is the final phase of the turn,
+#    pass the turn to the opponent
+#  - TODO: If the current phase is the discard step and
+#    players have too many cards in hand, do not allow
+#    progression to the next phase
+def nextPhase(group = table, x = 0, y = 0): 
+   mute()
+   phase = currentPhase()
+   #if phase[1] == 6 and not enforceHandLimits():
+       #return
+   if phase[1] == 7: 
+      nextTurn(findOpponent())
+      return  
+   else:
+    setPhase(phase[1]+1)
+
+# manageDrawPhase
+# Only called by the handlePhase event handler.
+# Initializes any player variables for the current turn.
+# Calls the "drawThree" action to Draw 3 cards.
+# Automatically advances to the Planning Step.
+# TODO:
+#  - Update the OnTurnPassed event handler to automatically enter this phase
+#  - Add any "Start of Turn" triggers
+#  - Add any "when cards are drawn" trigger handlers
+def manageDrawPhase():
+    # TODO: Add Any Start of Turn triggers here
+    me.setGlobalVariable("combatDeclared", "False")
+    drawThree()
+    nextPhase()
+
+# managePlanningPhase
+# Allow the Player to Play planning step cards. Make sure they know
+# how to invoke the PowerUp function and how to end their planning step.
+def managePlanningPhase():
+    whisper("Play Setups, Drills, Allies, or Dragon Balls.")
+    whisper("Press Ctrl+P to Power Up your personalities. This function does not currently manage active PUR modifiers.")
+    whisper("Press Ctrl+Enter to end your Planning Step and Declare/Skip Combat (you will not be able to inspect piles while the dialog is open).")
+
+# managePowerUpPhase
+# Manage Combat Declaration and enter the appropriate phase if combat
+# was declared or skipped.
+# TODO: 
+#   - Call the powerUp function automatically (when it can manage PUR modifiers)
+#   - Rebrand the phase in the game definition from "Declare" to "Power Up"
+def managePowerUpPhase():
+    #powerUp(None)
+    choices = ['Declare Combat', 'Skip Combat']
+    choice = askChoice("Declare Phase", choices)
+    if choice == 1:
+        me.setGlobalVariable("combatDeclared", "True")
+        setPhase(4) # Jump to entering combat phase
+    else:
+        setPhase(6) # Jump to Discard phase
+
+# enforceHandLimits
+# Checks each player's hand size against their maximum hand size
+# Returns False if hand sizes would block moving out of the discard step.
+# TODO: Account for cases where maxHandSize is greater than 1. Until then, always return True
+def enforceHandLimits():
+    # Until all ways a player's hand limit can be modified are accounted for, we must trust the players
+    return True
+    
+    if len(me.hand) > me.getGlobalVariable("maxHandSize") or len(findOpponent().hand) > findOpponent().getGlobalVariable("maxHandSize"):
+        return False
+    return True
+
+# manageRejuvenatePhase
+# If combat was not declared this turn, present the option to
+# rejuvenate 1.
+# TODO:
+#   - Add trigger window for "Start of Rejuvenation Step"
+#   - Add triggers for "when cards are Rejuvenated"
+#   - Automatically move to the next phase (turn)
+def manageRejuvenatePhase():
+    if not eval(me.getGlobalVariable("combatDeclared")):
+        whisper("Combat was not declared this turn. You may Rejuvenate 1.")
+        choices = ['Rejuvenate', 'Decline']
+        choice = askChoice("Rejuvenate 1?", choices)
+        if choice == 1:
+            rejuvenate(1)
+    # Can't automatically go to the next phase until effects like Popo are handled
+    #nextPhase()
+
+# rejuvenate
+# Arguments:
+#   count: (int) The number of cards to Rejuvenate
+# Moves <count> cards from the top of a player's discard piles
+# to the bottom of their Life Deck.
+# TODO:
+#   - Look at cards to be rejuvenated at trigger any "when rejuvenated" effects.
+#   - Look for effects that prevent or modify rejuvenation and make sure they are applied.
+def rejuvenate(count = 1):
+    for card in me.piles["Discard Pile"].top(count): card.moveToBottom(me.piles["Life Deck"])
+
+def lookupAttackTable(group, x = 0, y = 0):
+    mute()
+    defenderPL = remoteCall(players[1], "lookupPowerLevel", [group, x, y])
+    attackerPL = lookupPowerLevel(group, x, y)
+    update()
+    return calculateAT(me.getGlobalVariable("powerLevel"), players[1].getGlobalVariable("powerLevel"))
+
+def calculateAT(attackerPL, defenderPL):
+    mute()
+    attackerBase = 1 + getBaseAT(int(attackerPL.replace(',','')))
+    defenderBase = getBaseAT(int(defenderPL.replace(',','')))
+    if defenderBase > attackerBase:
+        return 0
+    return attackerBase - defenderBase
+
+def getBaseAT(p):
+    mute()
+    thresholds = [1000, 10000, 100000, 500000, 1500000]
+    base = 0
+    for threshold in thresholds:
+        if p >= threshold:
+            base += 1
+    return base
+
+def lookupPowerLevel(group, x = 0, y = 0):
+    mute()
+    personalitiesInTable = [c for c in table if c.controller == me]
+    for card in personalitiesInTable:
+        if re.search(r'Hero', card.type) or re.search(r'Villain', card.type) or re.search(r'Personality', card.type) or re.search(r'Ally', card.type):
+            try:
+                me.setGlobalVariable("powerLevel", card.properties["Power Rating"].split(";")[card.markers[CounterMarker]])
+            except:
+                pass

--- a/scripts/engine.py
+++ b/scripts/engine.py
@@ -1,3 +1,10 @@
+####################################################
+#  engine.py
+# This script contains functions that manage the DBZ
+# game engine.
+####################################################
+
+
 import re
 
 # ===================
@@ -6,7 +13,7 @@ import re
 
 # gameSetup 
 # This function prepares the game for the first turn.
-# It should be called by both players.
+# It should be called on behalf of each player.
 # Invokes 'faceUpAll' to turn MP/Mastery face up.
 # Shuffles the player's Life Deck
 # Searches the table for the player's MP and sets its
@@ -19,7 +26,7 @@ def gameSetup():
             c.markers[CounterMarker] = 5
 
 # determineFirstPlayer
-# This function should be called by only one player.
+# This function should be called on behalf of one player.
 # Randomly determine which player will have the option
 # of going first, and present the choice to that player.
 # TODO: Add "Before the first turn" effects (Currently
@@ -52,26 +59,6 @@ def chooseFirstPlayer():
 # =================
 # Phase Management
 # =================
-
-# nextPhase
-# Invoked by the Active Player by pressing Ctrl+Enter
-# Increments the phase counter using setPhase
-# Exceptions:
-#  - If the current phase is the final phase of the turn,
-#    pass the turn to the opponent
-#  - TODO: If the current phase is the discard step and
-#    players have too many cards in hand, do not allow
-#    progression to the next phase
-def nextPhase(group = table, x = 0, y = 0): 
-   mute()
-   phase = currentPhase()
-   #if phase[1] == 6 and not enforceHandLimits():
-       #return
-   if phase[1] == 7: 
-      nextTurn(findOpponent())
-      return  
-   else:
-    setPhase(phase[1]+1)
 
 # manageDrawPhase
 # Only called by the handlePhase event handler.
@@ -140,6 +127,12 @@ def manageRejuvenatePhase():
             rejuvenate(1)
     # Can't automatically go to the next phase until effects like Popo are handled
     #nextPhase()
+
+# ==========================
+# End Phase Management
+# ==========================
+
+
 
 # rejuvenate
 # Arguments:

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1,7 +1,24 @@
-# === Event Handlers
+####################################################
+#  events.py
+# This script contains event handler functions for
+# the events listed in the game definition.
+####################################################
+
 import re
 import collections
 import time
+
+# boardInit
+# Trigger: OnTableLoaded (whenever the game is loaded for the
+# first time)
+# Arguments: None
+# Sets the default value (disabled) for automationEnabled
+def boardInit():
+    setGlobalVariable("automationEnabled", "False")
+    whisper("Press Ctrl+A to enable Game Setup Automation for both players.")
+    whisper("This automation will play your MP and Mastery (face down) to the table when your deck is loaded.")
+    whisper("When both players have loaded a deck, cards will turn face up, decks will be shuffled, and the first player will be randomly decided.")
+    whisper("Press Ctrl+Z to disable Game Setup Automation once enabled.")
 
 # gameInit
 # Trigger: OnGameStarted (whenever the game is loaded or reset)
@@ -21,8 +38,12 @@ def gameInit():
 # Level 1 MP, and move those two cards to the table face-down.
 # If the other player has already loaded their deck, both players
 # call "gameSetup" and then the first player is determined.
+# This functionality can be opted out of by disabling Game Setup
+# Automation.
 def loadDeck(args):
     mute()
+    if not eval(getGlobalVariable("automationEnabled")):
+        return
     if not me.isInverted:
         mp_x_offset = HostPlayerMP_x_Offset
         mp_y_offset = HostPlayerMP_y_Offset

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1,13 +1,77 @@
-
+# === Event Handlers
 import re
 import collections
 import time
 
-def loadDeck(player,groups):   
-   mute()
-   init()
-   if player == me:
-      table.create("f5f6e310-629e-456f-af29-f8df2d11e6b5", playerside() * -60, yaxisMove(), 1, True) # The OK Button
-      table.create("54afa74e-b2c4-4010-b407-39909f55481a", 0, yaxisMove(), 1, True) # The Wait! Button
-      table.create("a4f448b9-449c-40d1-b387-301e3a1b5fc6", playerside() * 60, yaxisMove(), 1, True) # The Actions? Button
-   
+# gameInit
+# Trigger: OnGameStarted (whenever the game is loaded or reset)
+# Arguments: None
+# Sets the number of loaded decks to 0
+def gameInit():
+    setGlobalVariable("numLoadedDecks", "0")
+
+# loadDeck
+# Trigger: OnDeckLoaded
+# Arguments:
+#   args: {
+#         player: (Player) player that loaded a deck
+#         groups: (list<Group>) List of groups to which cards were added
+#       }
+# When a deck is loaded, search "Starting" for the player's Mastery and
+# Level 1 MP, and move those two cards to the table face-down.
+# If the other player has already loaded their deck, both players
+# call "gameSetup" and then the first player is determined.
+def loadDeck(args):
+    mute()
+    if not me.isInverted:
+        mp_x_offset = HostPlayerMP_x_Offset
+        mp_y_offset = HostPlayerMP_y_Offset
+        mastery_x_offset = HostPlayerMastery_x_Offset
+        mastery_y_offset = HostPlayerMastery_y_Offset
+    else:
+        mp_x_offset = GuestPlayerMP_x_Offset
+        mp_y_offset = GuestPlayerMP_y_Offset
+        mastery_x_offset = GuestPlayerMastery_x_Offset
+        mastery_y_offset = GuestPlayerMastery_y_Offset
+
+    if args.player == me:
+        setGlobalVariable("numLoadedDecks", str( 1 + eval(getGlobalVariable("numLoadedDecks")) ) )
+        args.player.setGlobalVariable("maxHandSize", 1)
+        for card in args.player.piles["Starting"]:
+            if card.Type == "Mastery":
+                card.moveToTable(mastery_x_offset, mastery_y_offset, True)
+            elif card.properties["Card Level"] == "1":
+                card.moveToTable(mp_x_offset, mp_y_offset, True)
+        if eval(getGlobalVariable("numLoadedDecks")) > 1:
+            gameSetup()
+            remoteCall(players[1], "gameSetup", [])
+            update()
+            determineFirstPlayer()
+
+# handlePhase
+# Trigger: OnPhasePassed
+# Arguments:
+#   args: {
+#         name: str(<name of the previous phase>),
+#         id: int(<index of the previous phase>),
+#         force: bool(<skip player-defined stops>)
+#       }
+# Special Note: This is called when _exiting_ a phase,
+# not when entering it.
+# This handler is called by both players, so only the
+# Active Player should perform any functions.
+# Calls the appropriate "Manage*Phase" function.
+def handlePhase(args):
+    currentPhaseIndex = args.id + 1
+    if(getActivePlayer() == me):
+        if currentPhaseIndex == 1:
+            manageDrawPhase()
+        elif currentPhaseIndex == 2:
+            managePlanningPhase()
+        elif currentPhaseIndex == 3:
+            managePowerUpPhase()
+        #elif currentPhaseIndex == 4:
+        #elif currentPhaseIndex == 5:
+        #elif currentPhaseIndex == 6:
+        elif currentPhaseIndex == 7:
+            manageRejuvenatePhase()

--- a/scripts/plugin.py
+++ b/scripts/plugin.py
@@ -16,7 +16,7 @@ def verifySaveDirectory(group,x=0,y=0):
                 filename = dir.replace('GameDatabase','Decks').replace('383a6ac2-6e52-40a5-980f-fade09e4908b','Dragon Ball Z')
         else:
                 filename = "Decks\Dragon Ball Z".join(dir.rsplit('OCTGN',1))
-        notify(filename)
+        #notify(filename)
         try:
                 nt.mkdir(filename)
         except:
@@ -27,7 +27,7 @@ def verifySaveDirectory(group,x=0,y=0):
         except:
                 pass
 
-def autosave(p, x=0, y=False):
+def autosave(args):
         global autosaveMode
         autosaveMode = getSetting("autosaveMode", False)
         if autosaveMode:

--- a/sets/05dea1dd-ba0f-412b-8560-d829952f8847/set.xml
+++ b/sets/05dea1dd-ba0f-412b-8560-d829952f8847/set.xml
@@ -750,7 +750,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="500,000; 300,000; 100,000; 70,000; 40,000; 10,000; 8,000; 6,000; 4,000; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 4000; 6000; 8000; 10000; 40000; 70000; 100000; 300000; 500000" />
       <property name="Text" value="(Your Life Deck may include up to 3 copies of each Ally with &quot;Cell Jr.&quot; in the title.) POWER: Physical attack. You may discard an Ally with &quot;Cell Jr.&quot; in the title from your hand. If you do, this attack cannot be stopped. DAMAGE: 4 stages. HIT: Search your Life Deck for a card with a CONSTANT effect and play it." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -761,7 +761,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="700,000; 500,000; 300,000; 100,000; 90,000; 80,000; 70,000; 60,000; 50,000; 40,000; 0" />
+      <property name="Power Rating" value="0; 40000; 50000; 60000; 70000; 80000; 90000; 100000; 300000; 500000; 700000" />
       <property name="Text" value="CONSTANT: Once per combat, you may discard an Ally with &quot;Cell Jr.&quot; in the title from your hand to stop an attack. POWER: Physical attack. DAMAGE: 5 +X stages. X = the number of personalities with &quot;Cell Jr.&quot; in the title in your discard pile." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -772,7 +772,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="900,000; 700,000; 500,000; 400,000; 300,000; 200,000; 100,000; 75,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 75000; 100000; 200000; 300000; 400000; 500000; 700000; 900000" />
       <property name="Text" value="CONSTANT: You may Rejuvenate an Ally with &quot;Cell Jr.&quot; in the title from your hand to stop a physical or energy attack. Physical attack. Search your discard pile for 2 Allies with &quot;Cell Jr.&quot; in the title and Rejuvenate them. DAMAGE: 1 life card. HIT: Search your Life Deck for an Ally with &quot;Cell Jr.&quot; in the title and place it in your hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -783,7 +783,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="6" />
-      <property name="Power Rating" value="1,100,000; 900,000; 700,000; 500,000; 400,000; 300,000; 200,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 200000; 300000; 400000; 500000; 700000; 900000; 1100000" />
       <property name="Text" value="CONSTANT: As an action during combat, you may banish an Ally with &quot;Cell Jr.&quot; in the title from your hand to destroy the top 3 cards of your opponent's Life Deck. Your physical attacks that do not have AT base damage deal +3 stages of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -805,7 +805,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="287; 257; 227; 197; 167; 137; 107; 77; 47; 17; 0" />
+      <property name="Power Rating" value="0; 17; 47; 77; 107; 137; 167; 197; 227; 257; 287" />
       <property name="Text" value="CONSTANT: Whenever you perform an attack, destroy the top card of your opponent's Life Deck. POWER: Physical attack. You may shuffle a card from your hand into your Life Deck to draw a card. DAMAGE: 1 life card. HIT: Your next attack this combat cannot be stopped." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -816,7 +816,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="387; 357; 327; 297; 267; 237; 207; 177; 147; 117; 0" />
+      <property name="Power Rating" value="0; 117; 147; 177; 207; 237; 267; 297; 327; 357; 387" />
       <property name="Text" value="CONSTANT: Whenever one of your attacks is stopped, banish the top card of your opponent's Life Deck. If a Dragon Ball is banished in this way, you may play it. POWER: The next non-Styled attack you perform this combat cannon be stopped." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -827,7 +827,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="487; 467; 447; 427; 407; 387; 367; 347; 327; 307; 0" />
+      <property name="Power Rating" value="0; 307; 327; 347; 367; 387; 407; 427; 447; 467; 487" />
       <property name="Text" value="CONSTANT: Whenever you perform an attack, banish the top card of your opponent's Life Deck. POWER: Look at your opponent's hand and choose non-Dragon Ball card in it. Banish that card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -838,7 +838,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="0" />
-      <property name="Power Rating" value="100,000; 90,000; 80,000; 70,000; 60,000, 50,000; 40,000; 30,000; 20,000; 10,000; 0" />
+      <property name="Power Rating" value="100000; 90000; 80000; 70000; 60000, 50000; 40000; 30000; 20000; 10000; 0" />
       <property name="Text" value="(This personality cannot gain stages.) CONSTANT: While you control 1 Ally, your effects that destroy cards from the top of your opponent's Life Deck have that amount increased by 1. If you MP is Cell, your opponent's attacks deal -1 life card of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -849,7 +849,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="0" />
-      <property name="Power Rating" value="100,000; 90,000; 80,000; 70,000; 60,000; 50,000; 40,000; 30,000; 20,000; 10,000; 0" />
+      <property name="Power Rating" value="0; 10000; 20000; 30000; 40000; 50000; 60000; 70000; 80000; 90000; 100000" />
       <property name="Text" value="(This personality cannot gain stages.) CONSTANT: When this card is leaving play, you may banish it to destroy the top card of your opponent's Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -860,7 +860,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="0" />
-      <property name="Power Rating" value="100,000; 90,000; 80,000; 70,000; 60,000; 50,000; 40,000; 30,000; 20,000; 10,000; 0" />
+      <property name="Power Rating" value="0; 10000; 20000; 30000; 40000; 50000; 60000; 70000; 80000; 90000; 100000" />
       <property name="Text" value="(This personality cannot gain stages.) POWER: Physical attack. Allies you control cannot perform attacks this combat. DAMAGE 3 +X stages. X= the number of Allies in play with &quot;Cell Jr.&quot; in the title. HIT: Shuffle all Allies you control with &quot;Cell Jr.&quot; in the title into their owner's Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -871,7 +871,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="10; 9; 8; 7; 6; 5; 4; 3; 2; 1; 0" />
+      <property name="Power Rating" value="0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10" />
       <property name="Text" value="CONSTANT: Players play with their hand revealed. Allies gain &quot;Endurance 1.&quot;" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -882,7 +882,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="5; 5; 4; 4; 3; 3; 2; 2; 1; 1; 0" />
+      <property name="Power Rating" value="0; 1; 1; 2; 2; 3; 3; 4; 4; 5; 5" />
       <property name="Text" value="(If you MP is Hercule, you may use the power regardless of your MP's power stage.) POWER: Stops a physical or energy attack. Shuffle this card into your Life Deck after use." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -893,7 +893,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="12; 11; 10; 9; 8; 7; 6; 5; 4; 3; 0;" />
+      <property name="Power Rating" value="0; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12" />
       <property name="Text" value="(If your MP is Chi-Chi, Goku, Gohan, Goten, Pan, or Videl, Rejuvenate 3 when this card enters play.) CONSTANT: Damage from attacks can only be modified by the effects of Physical Combat or Energy Combat cards." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -904,7 +904,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="25; 23; 21; 19; 17; 15; 13; 11; 9; 7; 0" />
+      <property name="Power Rating" value="0; 7; 9; 11; 13; 15; 17; 19; 21; 23; 25" />
       <property name="Text" value="(If your MP is Yamcha, you may choose him with this power effect.) POWER: Choose a non- INSTANT/non-CONSTANT Power of an Ally in play that isn't Puar. Use that Power." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1619,7 +1619,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="800,000; 400,000; 200,000; 100,000; 50,000; 25,000; 10,000; 5,000; 2,500; 1,250; 0" />
+      <property name="Power Rating" value="0; 1250; 2500; 5000; 10000; 25000; 50000; 100000; 200000; 400000; 800000" />
       <property name="Text" value="CONSTANT: Your attacks deal +1 life card of damage. [INSTANT] POWER: Use when entering combat. Draw a card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1630,7 +1630,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="1,250,000; 1,000,000; 750,000; 500,000; 250,000; 100,000; 80,000; 60,000; 40,000; 20,000; 0" />
+      <property name="Power Rating" value="0; 20000; 40000; 60000; 80000; 100000; 250000; 500000; 750000; 1000000; 1250000" />
       <property name="Text" value="CONSTANT: Your attacks deal +1 life card of damage and your opponent's attacks deal -1 life card of damage. POWER: Draw the bottom card of your discard pile. You may discard a card from your hand to use a critical damage effect." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1641,7 +1641,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="1,750,000; 1,500,000; 1,250,000; 1,000,000; 750,000; 500,000; 250,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 250000; 500000; 750000; 1000000; 1250000; 1500000; 1750000" />
       <property name="Text" value="CONSTANT: Your attacks deal +2 life cards of damage. POWER: Physical attack. Draw the top or bottom card of your discard pile. DAMAGE: AT +2 life cards." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1652,7 +1652,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="2,400,000; 2,000,000; 1,600,000; 1,200,000; 800,000; 400,000; 100,000; 50,000; 25,000; 12,500; 0" />
+      <property name="Power Rating" value="0; 12500; 25000; 50000; 100000; 400000; 800000; 1200000; 1600000; 2000000; 2400000" />
       <property name="Text" value="CONSTANT: Your attacks deal +2 life cards of damage and your opponent's attack deal -2 life cards of damage. POWER: Search your Life Deck, discard pile, or Banished Zone for a Styled card and place it into your hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1674,7 +1674,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="250,000; 175,000; 100,000; 80,000; 60,000; 40,000; 20,000; 10,000; 5,000; 2,500; 0" />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 20000; 40000; 60000; 80000; 100000; 175000; 250000" />
       <property name="Text" value="(Damage from your non-Styled attacks can only be modified by this card's effect.) CONSTANT: Your non-Styled attacks deal +2 life cards of damage. POWER: Energy attack costing 1 stage. Banish a card from your opponent's discard pile. DAMAGE: 1 life card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1685,7 +1685,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="950,000; 650,000; 350,000; 100,000; 80,000; 60,000; 40,000; 20,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 20000; 40000; 60000; 80000; 100000; 350000; 650000; 950000" />
       <property name="Text" value="(When you reach this level during combat, your opponent can only attack or pass in his or her next action this combat.) CONSTANT: Your non-Styled attacks deal +1 life card of damage and cannot have their damage prevented. POWER: Raise your anger 1 level. Your MP gains 3 stages." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1696,7 +1696,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,500,000; 1,200,000; 900,000; 600,000; 300,000; 150,000; 100,000; 50,000; 25,000; 12,500; 0" />
+      <property name="Power Rating" value="0; 12500; 25000; 50000; 100000; 150000; 300000; 600000; 900000; 1200000; 1500000" />
       <property name="Text" value="(When you reach this level during combat, your opponent must pass for his or her next action this combat.) CONSTANT: The first time each combat one of your non-Styled attack cards is stopped, it says in play to be used a second time this combat. Your non-Styled attacks deal +3 life cards of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1707,7 +1707,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="6" />
-      <property name="Power Rating" value="2,000,000; 1,700,000; 1,400,000; 1,100,000; 800,000; 500,000; 200,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 200000; 500000; 800000; 1100000; 1400000; 1700000; 2000000" />
       <property name="Text" value="(When you reach this level during combat, your opponent must pass for his or her next action this combat.) CONSTANT: Your non-Styled attacks cannot be stopped and deal +3 life cards of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1729,7 +1729,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="1,000,000; 500,000; 100,000; 25,000; 20,000; 15,000; 10,000; 5,000; 2,500; 1,250; 0" />
+      <property name="Power Rating" value="0; 1250; 2500; 5000; 10000; 15000; 20000; 25000; 100000; 500000; 1000000" />
       <property name="Text" value="[INSTANT] POWER: Use when entering combat. Search your Life Deck for an Ally with &quot;Cell Jr.&quot; in the title and play it. POWER: Destroy the top card of your opponent's Life Deck. Shuffle an Ally in play into its owner's Life Deck to raise or lower a player's anger 2 levels." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1740,7 +1740,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="1,500,000; 1,000;000; 500,000; 250,000; 125,000; 95,000; 65,000; 35,000; 5,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 5000; 35000; 65000; 95000; 125000; 250000; 500000; 1000000; 1500000" />
       <property name="Text" value="[INSTANT] POWER: Use when entering combat. Search your Life Deck, discard pile, or Banished Zone for an Ally with &quot;Cell Jr.&quot; in the title and play it. POWER: You may set your MP to its 0 power stage. Destroy the top 3 cards of your opponent's Life Deck. Shuffle an Ally in ply into its owner's Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1751,7 +1751,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="2,000,000; 1,400,000; 1,000,000; 500,000; 400,000; 300,000; 200,000; 100,000; 25,000; 10,000; 0" />
+      <property name="Power Rating" value="0; 10000; 25000; 100000; 200000; 300000; 400000; 500000; 1000000; 1400000; 2000000" />
       <property name="Text" value="[INSTANT] POWER: Use when entering combat .Search your Life Deck, discard pile, or Banished Zone for Saiyan Ally and play it. Physical attack. If you control 2 or more Allies, destroy the top 5 cards of your opponent's Life Deck. DAMAGE: AT +6 stages." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1762,7 +1762,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="2,500,000; 2,000,000; 1,500,000; 1,000,000; 500,000; 400,000; 300,000; 200,000; 100,000; 50,000; 0" />
+      <property name="Power Rating" value="0; 50000; 100000; 200000; 300000; 400000; 500000; 1000000; 1500000; 2000000; 2500000" />
       <property name="Text" value="(This card's non-[INSTANT] power may only be used once per game.) [INSTANT] POWER: Use when entering combat. Search your Life Deck for a Styled card and place it into your hand. POWER: You may lower your MP 1 level to lower your opponent's MP 1 level. (Most Recent Printing)" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1784,7 +1784,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="700,000; 500,000; 300,000; 100,000; 75,000; 50,000; 25,000; 10,000; 5,000; 2,500; 0 " />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 25000; 50000; 75000; 100000; 300000; 500000; 700000 " />
       <property name="Text" value="CONSTANT: Your attacks are considered Styled. Whenever an Ally you control is banished, raise your anger 1 level. POWER: Physical attack. You may banish an Ally. DAMAGE: AT +2 life cards." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1795,7 +1795,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="1,100,000; 900,000; 700,000; 500,000; 300,000; 100,000; 50,000; 25,000; 12,500; 6,250; 0" />
+      <property name="Power Rating" value="0; 6250; 12500; 25000; 50000; 100000; 300000; 500000; 700000; 900000; 1100000" />
       <property name="Text" value="CONSTANT: Your attacks are considered Styled. Whenever your MP would advance a level, you may lower your MP 1 level instead. POWER: Discard a card from your hand to search your Life Deck for a Styled [attack] or [shield] card and place it into your hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1806,7 +1806,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,700,000; 1,400,000; 1,100,000; 800,000; 500,000; 200,000; 100,000; 50,000; 25,000; 12,500; 0" />
+      <property name="Power Rating" value="0; 12500; 25000; 50000; 100000; 200000; 500000; 800000; 1100000; 1400000; 1700000" />
       <property name="Text" value="CONSTANT: Your attacks are considered Styled and deal +2 stages of damage. POWER: Physical attack. You may banish a Setup, Drill, or Ally. DAMAGE: 4 stages." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1817,7 +1817,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="6" />
-      <property name="Power Rating" value="2,800,000; 2,000,000; 1,200,000; 900,000; 600,000; 300,000; 200,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 200000; 300000; 600000; 900000; 1200000; 2000000; 2800000" />
       <property name="Text" value="CONSTANT: Your attacks are considered Styled. Your physical attacks can only be stopped by Physical Combat cards. Your energy attacks can only be stopped by Energy Combat cards. POWER: The next attack you perfom this combat has its power stage cost reduced to 0 and its damage cannot be prevented." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1839,7 +1839,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="5; 10; 15; 20; 25; 30; 35; 40; 45; 50; 0" />
+      <property name="Power Rating" value="0; 50; 45; 40; 35; 30; 25; 20; 15; 10; 5" />
       <property name="Text" value="(Your Life Deck cannot include cards that perform energy attacks.) CONSTANT: Your attacks deal +100 stages of damage. Your attacks cannot have their damage modified by your effects. POWER: Physical attack. Your MP gains 5 stages. Search your Life Deck for &quot;Hercule Dynamite Kick&quot; and place it into your hand. DAMAGE: 1 stage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1850,7 +1850,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="5; 10; 15; 20; 25; 30; 35; 40; 45; 50; 0"></property>
+      <property name="Power Rating" value="0; 50; 45; 40; 35; 30; 25; 20; 15; 10; 5"></property>
       <property name="Text" value="CONSTANT: Your Named cards cannot have their damage modified by your effects. Your opponent's attacks deal -3 stages and -3 life cards of damage. You cannot use the effects of CONSTANT Drills. Physical attack. Search your Life Deck for &quot;Hercule's Dynamite Kick&quot; and place it into your hand. DAMAGE 2 stages." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1861,7 +1861,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="5; 10; 15; 20; 25; 30; 35; 40; 45; 50; 0" />
+      <property name="Power Rating" value="0; 50; 45; 40; 35; 30; 25; 20; 15; 10; 5" />
       <property name="Text" value="(Your opponent cannot use effects that lower your MP 1 or more levels.) CONSTANT: Your anger cannot be lowered by critical damage effects. All attacks deal +1 stage of damage. Your damage modifiers are doubled. Your named cards cannot have their damage modified and gain &quot;HIT: Raise your anger 1 level.&quot;" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1872,7 +1872,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="5; 10; 15; 20; 25; 30; 35; 40; 45; 50; 0" />
+      <property name="Power Rating" value="0; 50; 45; 40; 35; 30; 25; 20; 15; 10; 5" />
       <property name="Text" value="CONSTANT: Your attacks deal +2 life cards of damage. Whenver you use a Named card, destroy the top card of your opponent's Life Deck and lower each player's anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1894,7 +1894,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="225,000; 175,000; 125,000; 75,000; 25,000; 20,000; 15,000; 10,000; 5,000; 2,500; 0" />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 15000; 20000; 25000; 75000; 125000; 175000; 225000" />
       <property name="Text" value="CONSTANT: Whenever you raise your anger during combat, that amount is doubled." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1905,7 +1905,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="850,000; 700,000; 550,000; 250,000; 100,000; 50,000; 25,000; 12,500; 6,250; 0" />
+      <property name="Power Rating" value="850000; 700000; 550000; 250000; 100000; 50000; 25000; 12500; 6250; 0" />
       <property name="Text" value="CONSTANT: Whenever you play a Named card, you may use a critical damage effect. POWER: Stop a physical attack. You may rejuvenate a card with &quot;Sword&quot; in the title from your Banished zone to raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1916,7 +1916,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="1,250,000; 1,000;000; 750,000; 500,000; 250,000; 200,000; 150,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 150000; 200000; 250000; 500000; 750000; 1000000; 1250000" />
       <property name="Text" value="CONSTANT: Your attacks deal +2 stages of damage. Whenever your anger would be lowered by any amount, its lowered by 1 instead. POWER: Physical attack. Skip your next action this combat. DAMAGE: 6 stages." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1927,7 +1927,7 @@
       <property name="Rarity" value="Dragon Rare" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,850,000; 1,550,000; 1,250,000; 950,000; 650,000; 350,000; 250,000; 150,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 150000; 250000; 350000; 650000; 950000; 1250000; 1550000; 1850000" />
       <property name="Text" value="CONSTANT: Your attacks with &quot;Sword&quot; in the title cannot be stopped and gain &quot;Raise your anger 1 level.&quot; POWER: Skip your next 2 actions this combat. Raise your anger 2 levels." />
       <property name="Limit per Deck" value="1" />
     </card>

--- a/sets/0978f8f6-793c-423c-a4fa-f468e73b333e/set.xml
+++ b/sets/0978f8f6-793c-423c-a4fa-f468e73b333e/set.xml
@@ -729,7 +729,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 5,000; 10,000; 20,000; 50,000; 100,000; 200,000; 300,000; 400,000; 600,000; 800,000" />
+<property name="Power Rating" value="0; 5000; 10000; 20000; 50000; 100000; 200000; 300000; 400000; 600000; 800000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -768,7 +768,7 @@
 <property name="Traits" value="God, Namekian" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 1; 20; 30; 40; 50; 100; 200; 400; 600; 1,000" />
+<property name="Power Rating" value="0; 1; 20; 30; 40; 50; 100; 200; 400; 600; 1000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -781,7 +781,7 @@
 <property name="Traits" value="Namekian, Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 800; 1,000; 3,000; 7,000; 10,000; 50,000; 100,000; 200,000; 500,000; 700,000" />
+<property name="Power Rating" value="0; 800; 1000; 3000; 7000; 10000; 50000; 100000; 200000; 500000; 700000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -794,7 +794,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 500; 750; 1,000; 1,500; 2,500; 5,000; 10,000; 40,000; 60,000; 100,000" />
+<property name="Power Rating" value="0; 500; 750; 1000; 1500; 2500; 5000; 10000; 40000; 60000; 100000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -807,7 +807,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 250; 500; 1,000; 2,000; 5,000; 10,000; 20,000; 40,000; 60,000; 100,000" />
+<property name="Power Rating" value="0; 250; 500; 1000; 2000; 5000; 10000; 20000; 40000; 60000; 100000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -846,7 +846,7 @@
 <property name="Traits" value="Majin, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 3,000; 6,000; 9,000; 25,000; 50,000; 150,000; 300,000; 450,000; 1,000,000; 1,500,000" />
+<property name="Power Rating" value="0; 3000; 6000; 9000; 25000; 50000; 150000; 300000; 450000; 1000000; 1500000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -859,7 +859,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 1,000; 4,000; 7,000; 10,000; 15,000; 25,000; 50,000; 100,000; 150,000; 250,000" />
+<property name="Power Rating" value="0; 1000; 4000; 7000; 10000; 15000; 25000; 50000; 100000; 150000; 250000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -872,7 +872,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 10,000; 50,000; 70,000; 90,000; 125,000; 250,000 500,000; 650,000; 725,000; 850,000" />
+<property name="Power Rating" value="0; 10000; 50000; 70000; 90000; 125000; 250000 500000; 650000; 725000; 850000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -885,7 +885,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 15,000; 50,000; 75,000; 100,000; 300,000; 500,000; 700,000; 900,000; 1,000,000; 1,200,000" />
+<property name="Power Rating" value="0; 15000; 50000; 75000; 100000; 300000; 500000; 700000; 900000; 1000000; 1200000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -898,7 +898,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="0; 25,000; 50,000; 200,000; 500,000; 800,000; 1,200,000; 1,500,000; 1,700,000; 1,900,000; 2,000,000" />
+<property name="Power Rating" value="0; 25000; 50000; 200000; 500000; 800000; 1200000; 1500000; 1700000; 1900000; 2000000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -911,7 +911,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 1,000; 3,000; 5,000; 8,000; 10,000; 15,000; 20,000; 40,000; 60,000; 100,000" />
+<property name="Power Rating" value="0; 1000; 3000; 5000; 8000; 10000; 15000; 20000; 40000; 60000; 100000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -924,7 +924,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 5,000; 10,000; 15,000; 30,000; 70,000; 80,000; 90,000; 100,000; 150,000; 300,000" />
+<property name="Power Rating" value="0; 5000; 10000; 15000; 30000; 70000; 80000; 90000; 100000; 150000; 300000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -937,7 +937,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 20,000; 40,000; 60,000; 100,000; 200,000; 400,000; 600,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 20000; 40000; 60000; 100000; 200000; 400000; 600000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -950,7 +950,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 1,000; 10,000; 15,000; 30,000; 70,000; 200,000; 400,000; 700,000; 1,000,000; 1,150,000" />
+<property name="Power Rating" value="0; 1000; 10000; 15000; 30000; 70000; 200000; 400000; 700000; 1000000; 1150000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -963,7 +963,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 2,000; 3,000; 4,500; 7,500; 15,000; 30,000; 60,000; 80,000; 115,000" />
+<property name="Power Rating" value="0; 1000; 2000; 3000; 4500; 7500; 15000; 30000; 60000; 80000; 115000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -976,7 +976,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 15,000; 25,000; 50,000; 80,000; 100,000; 200,000; 325,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 15000; 25000; 50000; 80000; 100000; 200000; 325000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -989,7 +989,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 5,000; 10,000; 15,000; 25,000; 40,000; 50,000; 100,000; 250,000; 500,000; 625,000" />
+<property name="Power Rating" value="0; 5000; 10000; 15000; 25000; 40000; 50000; 100000; 250000; 500000; 625000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -1002,7 +1002,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="0; 5,000; 10,000; 25,000; 50,000; 75,000; 250,000; 500,000; 1,000,000; 1,100,000; 1,200,000" />
+<property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 75000; 250000; 500000; 1000000; 1100000; 1200000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -1015,7 +1015,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 5,000; 8,000; 10,000; 15,000; 30,000; 60,000; 90,000; 120,000; 220,000" />
+<property name="Power Rating" value="0; 1000; 5000; 8000; 10000; 15000; 30000; 60000; 90000; 120000; 220000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1028,7 +1028,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 25,000; 50,000; 80,000; 100,000; 150,000; 300,000; 550,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 25000; 50000; 80000; 100000; 150000; 300000; 550000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -1041,7 +1041,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 7,000; 15,000; 50,000; 100,000; 250,000; 350,000; 500,000; 600,000; 675,000; 750,000" />
+<property name="Power Rating" value="0; 7000; 15000; 50000; 100000; 250000; 350000; 500000; 600000; 675000; 750000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -1054,7 +1054,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="0; 10,000; 20,000; 30,000; 70,000; 100,000; 400,000; 600,000; 800,000; 1,000,000; 1,000,100" />
+<property name="Power Rating" value="0; 10000; 20000; 30000; 70000; 100000; 400000; 600000; 800000; 1000000; 1000100" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -1067,7 +1067,7 @@
 <property name="Traits" value="Namekian" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 1,000; 2,500; 5,000; 10,000; 50,000; 75,000; 100,000; 150,000; 300,000; 350,000" />
+<property name="Power Rating" value="0; 1000; 2500; 5000; 10000; 50000; 75000; 100000; 150000; 300000; 350000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1080,7 +1080,7 @@
 <property name="Traits" value="Namekian" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 25,000; 50,000; 100,000; 150,000; 400,000; 600,000; 900,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 25000; 50000; 100000; 150000; 400000; 600000; 900000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -1093,7 +1093,7 @@
 <property name="Traits" value="Namekian" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 20,000; 40,000; 100,000; 300,000; 450,000; 700,000; 1,000,000; 1,150,000; 1,200,000; 1,450,000" />
+<property name="Power Rating" value="0; 20000; 40000; 100000; 300000; 450000; 700000; 1000000; 1150000; 1200000; 1450000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -1106,7 +1106,7 @@
 <property name="Traits" value="Namekian" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="0; 50,000; 100,000; 300,000; 500,000; 900,000; 1,300,000; 1,700,000; 2,000,000; 2,200,000; 2,450,000;" />
+<property name="Power Rating" value="0; 50000; 100000; 300000; 500000; 900000; 1300000; 1700000; 2000000; 2200000; 2450000;" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -1119,7 +1119,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 10,000; 20,000; 40,000; 50,000; 60,000; 125,000; 175,000; 225,000; 250,000; 300,000" />
+<property name="Power Rating" value="0; 10000; 20000; 40000; 50000; 60000; 125000; 175000; 225000; 250000; 300000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1132,7 +1132,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 10,000; 15,000; 25,000; 50,000; 100,000; 200,000; 300,000; 500,000; 600,000; 775,000" />
+<property name="Power Rating" value="0; 10000; 15000; 25000; 50000; 100000; 200000; 300000; 500000; 600000; 775000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -1145,7 +1145,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 20,000; 50,000; 75,000; 100,000; 200,000; 600,000; 800,000; 900,000; 1,000,000; 1,100,000" />
+<property name="Power Rating" value="0; 20000; 50000; 75000; 100000; 200000; 600000; 800000; 900000; 1000000; 1100000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -1158,7 +1158,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 50,000; 100,000; 400,000; 600,000; 800,000; 1,000,000; 1,150,000; 1,350,000; 1,550,000; 1,750,000" />
+<property name="Power Rating" value="0; 50000; 100000; 400000; 600000; 800000; 1000000; 1150000; 1350000; 1550000; 1750000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -1223,7 +1223,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 1,000; 3,000; 5,000; 10,000; 15,000; 25,000; 30,000; 100,000; 666,000; 900,000" />
+<property name="Power Rating" value="0; 1000; 3000; 5000; 10000; 15000; 25000; 30000; 100000; 666000; 900000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1236,7 +1236,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 10,000; 36,000; 55,000; 95,000; 100,000; 300,000; 666,000; 1,000,000; 1,500,000" />
+<property name="Power Rating" value="0; 1000; 10000; 36000; 55000; 95000; 100000; 300000; 666000; 1000000; 1500000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="2" />
 </card>
@@ -1249,7 +1249,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 15,000; 25,000; 50,000; 100,000; 150,000; 300,000; 666,000; 1,000,000; 1,700,000; 2,150,000" />
+<property name="Power Rating" value="0; 15000; 25000; 50000; 100000; 150000; 300000; 666000; 1000000; 1700000; 2150000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>
@@ -1262,7 +1262,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 30,000; 50,000; 100,000; 250,000; 666,000; 1,000,000; 1,500,000; 1,700,000; 2,000,000; 2,600,000" />
+<property name="Power Rating" value="0; 30000; 50000; 100000; 250000; 666000; 1000000; 1500000; 1700000; 2000000; 2600000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="4" />
 </card>
@@ -1288,7 +1288,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 750; 1,250; 2,500; 5,000; 10,000; 20,000; 40,000; 60,000; 80,000; 100,000" />
+<property name="Power Rating" value="0; 750; 1250; 2500; 5000; 10000; 20000; 40000; 60000; 80000; 100000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1301,7 +1301,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 5,000; 10,000; 25,000; 50,000; 100,000; 250,000; 500,000; 1,000,000; 10,000,000; 100,000,000" />
+<property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 100000; 250000; 500000; 1000000; 10000000; 100000000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="1" />
 </card>
@@ -1314,7 +1314,7 @@
 <property name="Traits" value="Saiyan, Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="" />
-<property name="Power Rating" value="0; 5,000; 10,000; 20,000; 40,000; 60,000; 80,000; 100,000; 125,000; 150,000; 175,000" />
+<property name="Power Rating" value="0; 5000; 10000; 20000; 40000; 60000; 80000; 100000; 125000; 150000; 175000" />
 <property name="Rarity" value="" />
 <property name="Card Level" value="3" />
 </card>

--- a/sets/0c99e3f3-2d55-4356-aade-c010edaf82cf/set.xml
+++ b/sets/0c99e3f3-2d55-4356-aade-c010edaf82cf/set.xml
@@ -517,7 +517,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 250; 500; 1,000; 4,000; 5,000; 10,000; 20,000; 40,000; 60,000; 80,000" />
+<property name="Power Rating" value="0; 250; 500; 1000; 4000; 5000; 10000; 20000; 40000; 60000; 80000" />
 <property name="Text" value="POWER: Physical attack. If stopped, draw a card. DAMAGE: 3 stages." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="" />
@@ -529,7 +529,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 250; 500; 1,000; 1,500; 2,500; 5,000; 10,000; 20,000; 30,000" />
+<property name="Power Rating" value="0; 250; 500; 1000; 1500; 2500; 5000; 10000; 20000; 30000" />
 <property name="Text" value="(If your MP is Frieza, Cooler or King Cold, you may use this Power regardless of your MP\'s power stage.) CONTINUOUS POWER: Cards cannot attack to personalities. POWER: Rejuvenate 1. Banish the bottom 3 cards of your opponent\'s discard pile." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="" />
@@ -541,7 +541,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 2,000; 2,500; 3,000; 3,500; 4,500; 6,000; 6,500; 8,000; 9,000; 10,000" />
+<property name="Power Rating" value="0; 2000; 2500; 3000; 3500; 4500; 6000; 6500; 8000; 9000; 10000" />
 <property name="Text" value="(If your MP is a Saiyan, you may use this Power regardless of your MP\'s power stage.) SHIELD POWER: Prevent all damage from a physical attack. If your MP is Vegeta, you may use this Power a second time this combat." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="" />
@@ -553,7 +553,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 10; 25; 50; 75; 100; 200; 250; 500; 600; 1,000" />
+<property name="Power Rating" value="0; 10; 25; 50; 75; 100; 200; 250; 500; 600; 1000" />
 <property name="Text" value="(If your MP is a Saiyan and the highest power level on your MP\'s Level 4 is 500,000 or less, your Life Deck may include up to 3 copies of this card and you may use this Power regardless of your MP\'s power stage.) POWER: Physical attack. Banish the top card of your opponent\'s discard pile. DAMAGE: 2 life cards or 2 stages." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="" />
@@ -565,7 +565,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 250; 500; 1,000; 1,500; 2,000; 2,500; 3,000; 3,500; 4,000; 4,500" />
+<property name="Power Rating" value="0; 250; 500; 1000; 1500; 2000; 2500; 3000; 3500; 4000; 4500" />
 <property name="Text" value="(If your MP is Bardock, once per combat you may place this card into play from your hand at 2 power stages above 0 to stop a hysical or energy attack.) CONTINUOUS POWER: Effects that destroy cards from the top of a player\'s Life Deck have that amount increased by 1." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="" />
@@ -577,7 +577,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 500; 1,000; 1,250; 1,500; 2,500; 4,500; 6,000; 6,500; 7,500; 8,000" />
+<property name="Power Rating" value="0; 500; 1000; 1250; 1500; 2500; 4500; 6000; 6500; 7500; 8000" />
 <property name="Text" value="CONTINUOUS POWER: Whenever a player searches your oponent\'s Life Deck, you may raise your anger 1 level. POWER: Destroy the top card of your Life Deck. Your opponent reveals their hand. Search your opponent\'s LIfe Deck for a card and destroy it." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -589,7 +589,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 9,000; 10,000; 15,000; 18,500; 20,000; 25,000; 30,000; 33,000; 35,000" />
+<property name="Power Rating" value="0; 1000; 9000; 10000; 15000; 18500; 20000; 25000; 30000; 33000; 35000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent lays with their hand revealed. Whenever an effect destroys cards from your opponent\'s Life Deck, you may raise your anger 1 level. POWER: Destroy the top card of your Life Deck to banish the bottom card of your oponent\'s discard pile. You may discard a card from your hand. If you do, your opponent discards a card from their hand." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -601,7 +601,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 5,000; 9,000; 10,000; 15,000; 30,000; 40,000; 70,000; 80,000; 90,000; 100,000" />
+<property name="Power Rating" value="0; 5000; 9000; 10000; 15000; 30000; 40000; 70000; 80000; 90000; 100000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent plays with their hand revealed. POWER: Search your opponent\'s Life Deck for up to 3 Styled cards and destroy them. Reveal the top 4 cards of your Life Deck and place them back in any order. Your opponent skips their next action this combat." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -613,7 +613,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 10,000; 25,000; 50,000; 100,000; 200,000; 400,000; 600,000; 800,000; 1,000,000; 1,100,000" />
+<property name="Power Rating" value="0; 10000; 25000; 50000; 100000; 200000; 400000; 600000; 800000; 1000000; 1100000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent plays with their hand revealed. At the end of each turn, your opponent discards their hand. POWER: Gain 4 stages. Destroy the top 3 cards of a player\'s Life Deck. The first Styled Setup destroyed by this effect is placed into play under your control." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -625,7 +625,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 5,000; 10,000; 25,000; 35,000; 40,000; 45,000; 50,000; 60,000; 80,000; 100,000" />
+<property name="Power Rating" value="0; 5000; 10000; 25000; 35000; 40000; 45000; 50000; 60000; 80000; 100000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal their life card damage as stages of damage instead. INSTANT POWER: Use after your attack deals 5 or more stages of damage. That attack is considered to deal critical damage. Raise your anger 2 levels. POWER: Rejuvenate 1. You may draw a card. If you do, discard a card." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -637,7 +637,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 10,000; 15,000; 20,000; 50,000; 100,000; 150,000; 160,000; 180,000; 200,000" />
+<property name="Power Rating" value="0; 10000; 15000; 20000; 50000; 100000; 150000; 160000; 180000; 200000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal their life card damage as stages of damage instead. Your attacks deal +1 stage of damage. POWER: Physical attack. Rejuvenate 1. This attack is considered to deal critical damage. DAMAGE: 5 stages. HIT: Raise your anger 1 level." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -649,7 +649,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 10,000; 25,000; 50,000; 125,000; 150,000; 200,000; 250,000; 460,000; 480,000; 600,000" />
+<property name="Power Rating" value="0; 10000; 25000; 50000; 125000; 150000; 200000; 250000; 460000; 480000; 600000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal their life card damage as stages of damage instead. Your attacks that deal 5 or more stages of damage are considered to deal critical damage. Whenever you deal critical damage, you may raise your anger 1 level. PPOWER: Physical attack. DAMAGE: 6 stages. HIT: Raise your anger 1 level. Rejuvenate 2. Banish an opponent\'s Setup, Drill or Ally." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -661,7 +661,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 10,000; 25,000; 50,000; 100,000; 150,000; 200,000; 300,000; 400,000; 500,000; 650,000" />
+<property name="Power Rating" value="0; 10000; 25000; 50000; 100000; 150000; 200000; 300000; 400000; 500000; 650000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal their life card damage as stages of damage instead. Your attacks that deal 5 or more stages of damage are considered to deal critical damage. Personalities cannot eb more than 5 stages above 0. POWER: Gain 3 stages. Choose a personality in play.  That personality loses 3 stages." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -697,7 +697,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 200; 300; 400; 500; 600; 700; 800; 900; 1,000; 1,050" />
+<property name="Power Rating" value="0; 200; 300; 400; 500; 600; 700; 800; 900; 1000; 1050" />
 <property name="Text" value="(When you advance to this level, you may shuffle a Dragon Ball in play back into its owner\'s Life Deck. Search your Banished Zone for an Earth Dragon Ball and place it into play.) CONTINUOUS POWER: When you control 3 or more Earth Dragon Balls, your oponent\'s attacks deal -3 stages of damage and your energy attacks deal +3 life cards of damage. POWER: Raise your anger 1 level. You may banish an Earth Dragon ball you control. If you do, search your Banished Zone for a Dragon Ball or Styled Drill and Rejuvenate it." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -709,7 +709,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 300; 400; 500; 600; 700; 800; 900; 1,000; 1,050; 1,100" />
+<property name="Power Rating" value="0; 300; 400; 500; 600; 700; 800; 900; 1000; 1050; 1100" />
 <property name="Text" value="(When you reach this level, cature an Earth Dragon Ball or place a Dragon Ball from your Banished Zone into play.) POWER: Energy attack costing 1 stage. If 5 or more Earth Dragon Balls are in play and/or in your Banished Zone, search your discard pile for a Styled Drill and play it and this attack cannot be stopped. DAMAGE: 5 life cards." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -721,7 +721,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 3,000; 4,000; 5,000; 6,000; 7,000; 8,000; 9,000; 10,000; 11,000" />
+<property name="Power Rating" value="0; 1000; 3000; 4000; 5000; 6000; 7000; 8000; 9000; 10000; 11000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal +2 stages of damage. POWER: Physical attack. Raise your anger 1 level. DAMAGE: AT +2 stages. HIT: Destroy a Drill." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />
@@ -733,7 +733,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 2,000; 4,000; 5,000; 7,000; 8,000; 9,000; 10,000; 10,500; 11,000" />
+<property name="Power Rating" value="0; 1000; 2000; 4000; 5000; 7000; 8000; 9000; 10000; 10500; 11000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks without \'anger\' printed in the text-box gain \'Raise your anger 1 level.\' POWER: Physical attack. Raise your anger 1 level. This attack is considered to deal critical damage. DAMAGE: 4 stages." />
 <property name="Limit per Deck" value="" />
 <property name="Endurance" value="" />

--- a/sets/0fae8ccc-256e-4a5c-8bb2-168b81b24e4f/set.xml
+++ b/sets/0fae8ccc-256e-4a5c-8bb2-168b81b24e4f/set.xml
@@ -15,7 +15,7 @@
 <property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 250; 500; 1,000; 2,000; 3,000; 4,000; 5,000; 6,000; 8,000; 10,000" />
+<property name="Power Rating" value="0; 250; 500; 1000; 2000; 3000; 4000; 5000; 6000; 8000; 10000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -28,7 +28,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 500; 1,000; 2,000; 3,000; 4,000; 5,000; 6,000; 7,000; 8,000; 9,001" />
+<property name="Power Rating" value="0; 500; 1000; 2000; 3000; 4000; 5000; 6000; 7000; 8000; 9001" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -41,7 +41,7 @@
 <property name="Traits" value="Namekian, Eartling, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 200; 400; 600; 800; 1,000; 1,500; 2,000; 2,500; 3,000; 3,500" />
+<property name="Power Rating" value="0; 200; 400; 600; 800; 1000; 1500; 2000; 2500; 3000; 3500" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -54,7 +54,7 @@
 <property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 400; 800; 1,200; 1,600; 2,000; 2,400; 2,800; 3,200; 3,600; 4,000 " />
+<property name="Power Rating" value="0; 400; 800; 1200; 1600; 2000; 2400; 2800; 3200; 3600; 4000 " />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -67,7 +67,7 @@
 <property name="Traits" value="God, Earthling, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 5,000; 10,000; 25,000; 50,000; 100,000; 250,000; 500,000; 1,000,000; 10,000,000; 100,000,000" />
+<property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 100000; 250000; 500000; 1000000; 10000000; 100000000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -80,7 +80,7 @@
 <property name="Traits" value="Namekian" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 900; 1,100; 1,300; 1,700; 2,200; 3,500; 4,500; 5,500; 7,000; 8,500" />
+<property name="Power Rating" value="0; 900; 1100; 1300; 1700; 2200; 3500; 4500; 5500; 7000; 8500" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -171,7 +171,7 @@
 <property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 450; 900; 4,500; 9,000; 19,000; 34,000; 49,000; 64,000; 79,000; 94,000" />
+<property name="Power Rating" value="0; 450; 900; 4500; 9000; 19000; 34000; 49000; 64000; 79000; 94000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -626,7 +626,7 @@
 <property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 7,500; 15,000; 30,000; 75,000; 150,000; 300,000; 600,000; 1,250,000; 25,000,000; 150,000,000" />
+<property name="Power Rating" value="0; 7500; 15000; 30000; 75000; 150000; 300000; 600000; 1250000; 25000000; 150000000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="2" />
 </card>
@@ -964,7 +964,7 @@
 <property name="Traits" value="God" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 10,000; 20,000; 50,000; 100,000; 200,000; 500,000; 1,000,000; 2,000,000; 20,000,000; 200,000,000" />
+<property name="Power Rating" value="0; 10000; 20000; 50000; 100000; 200000; 500000; 1000000; 2000000; 20000000; 200000000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -1016,7 +1016,7 @@
 <property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 15,000; 25,000; 200,000; 400,000; 650,000; 800,000; 1,000,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 15000; 25000; 200000; 400000; 650000; 800000; 1000000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="" />
 </card>
@@ -1029,7 +1029,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0, 9,999; 60,000; 80,000; 100,000; 150,000; 250,000; 300,000; 450,000; 500,000; 650,000" />
+<property name="Power Rating" value="0, 9999; 60000; 80000; 100000; 150000; 250000; 300000; 450000; 500000; 650000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="2" />
 </card>
@@ -1042,7 +1042,7 @@
 <property name="Traits" value="Earthling, Android" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,500; 5,000; 10,000; 15,000; 25,000; 50,000; 60,000; 80,000; 90,000; 100,000" />
+<property name="Power Rating" value="0; 1500; 5000; 10000; 15000; 25000; 50000; 60000; 80000; 90000; 100000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -1055,7 +1055,7 @@
 <property name="Traits" value="Android" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 500; 1,000; 5,000; 10,000; 25,000; 50,000; 100,000; 150,000; 200,000; 250,000" />
+<property name="Power Rating" value="0; 500; 1000; 5000; 10000; 25000; 50000; 100000; 150000; 200000; 250000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="1" />
 </card>
@@ -1068,7 +1068,7 @@
 <property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 12,500; 25,000; 50,000; 100,000; 200,500; 400,000; 600,000; 800,000; 900,000; 1,000,000" />
+<property name="Power Rating" value="0; 12500; 25000; 50000; 100000; 200500; 400000; 600000; 800000; 900000; 1000000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="3" />
 </card>
@@ -1159,7 +1159,7 @@
 <property name="Traits" value="Namekian, God" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 1,000; 2,000; 3,000; 5,000; 7,000; 9,000; 12,000; 15,000; 20,000; 30,000" />
+<property name="Power Rating" value="0; 1000; 2000; 3000; 5000; 7000; 9000; 12000; 15000; 20000; 30000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="" />
 </card>
@@ -1172,7 +1172,7 @@
 <property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 10; 50; 150; 250; 500; 750; 1,500; 2,500; 3,500; 5,000" />
+<property name="Power Rating" value="0; 10; 50; 150; 250; 500; 750; 1500; 2500; 3500; 5000" />
 <property name="Rarity" value="Promo" />
 <property name="Card Level" value="" />
 </card>

--- a/sets/32b3926d-0563-4b05-b8e7-9f2848b500d3/set.xml
+++ b/sets/32b3926d-0563-4b05-b8e7-9f2848b500d3/set.xml
@@ -46,7 +46,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="100,000; 75,000; 50,000; 25,000; 10,000; 5,000; 2,500; 1,500; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 1500; 2500; 5000; 10000; 25000; 50000; 75000; 100000" />
       <property name="Text" value="[CONSTANT]:  When entering combat, look at the top 4 cards of your Life Deck and put them back in any order.  Banish the top card of your opponent's discard pile." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -57,7 +57,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="700,000; 550,000; 400,000; 250,000; 100,000; 50,000; 10,000; 5,000; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 5000; 10000; 50000; 100000; 250000; 400000; 550000; 700000" />
       <property name="Text" value="[CONSTANT]:  When entering combat, look at the top 4 cards of a player's Life Deck and put them back in any order.  Banish a card in your opponent's discard pile." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -68,7 +68,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="75,000; 65,000; 55,000; 45,000; 35,000; 25,000; 15,000; 5,000; 2,500; 1,250;0" />
+      <property name="Power Rating" value="75000; 65000; 55000; 45000; 35000; 25000; 15000; 5000; 2500; 1250;0" />
       <property name="Text" value="POWER:  Energy attack costing 3 stages.  DAMAGE:  4 life cards.  Search your Life Deck for an Ally and place it into play at 4 power stages above 0.  HIT:  Choose one of your Allies in play, that Ally can make actions regardless of your MP's power stage" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -79,7 +79,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="125,000; 115,000; 105,000; 85,000; 65,000; 45,000; 25,000; 5,000; 2,500; 1,250; 0" />
+      <property name="Power Rating" value="0; 1250; 2500; 5000; 25000; 45000; 65000; 85000; 105000; 115000; 125000" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  4 life cards.  Search your discard pile for an Ally and place it into play at 5 power stages above 0.  Raise your anger X levels.  X = the number of your &quot;Ginyu Force&quot; Allies in play." />
       <property name="Limit per Deck" value="3" />
     </card>
@@ -90,7 +90,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="90,000; 80,000; 70,000; 60,000; 50,000; 40,000; 30,000; 20,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 20000; 30000; 40000; 50000; 60000; 70000; 80000; 90000" />
       <property name="Text" value="(Heroes only.)  POWER:  Energy attack costing 4 stages.  DAMAGE:  7 life cards.  Shuffle &quot;Chaozu&quot; into your Life Deck at the beginning of the next action this combat." />
       <property name="Limit per Deck" value="3" />
     </card>
@@ -101,7 +101,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="95,000; 80,000; 65,000; 50,000; 35,000; 20,000; 5,000; 4,000; 3,000; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 3000; 4000; 5000; 20000; 35000; 50000; 65000; 80000; 95000" />
       <property name="Text" value="(Heroes only.)  POWER:  Energy attack costing 2 stages.  DAMAGE:  3 life cards.  HIT:  Draw a card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -112,7 +112,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="50,000; 45,000; 40,000; 35,000; 30,000; 25,000; 20,000; 15,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 15000; 20000; 25000; 30000; 35000; 40000; 45000; 50000" />
       <property name="Text" value="(Villains only.)  POWER:  Stop a physical or energy attack.  Your attacks deal +2 stages and +2 life cards of damage this combat." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -123,7 +123,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="55,000; 45,000; 35,000; 30,000; 25,000; 20,000; 15,000; 10,000; 5,000; 2,500; 0" />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 15000; 20000; 25000; 30000; 35000; 45000; 55000" />
       <property name="Text" value="(Villains only.)  POWER:  Physical attack.  DAMAGE:  AT stages.  HIT:  You may have your MP pay 2 stages to draw the bottom of your discard pile." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -134,7 +134,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="8,000; 7,000; 6,000; 5,000; 4,000; 3,000; 2,000; 1,000; 500; 250; 0" />
+      <property name="Power Rating" value="0; 250; 500; 1000; 2000; 3000; 4000; 5000; 6000; 7000; 8000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  Setups cannot be used." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -675,7 +675,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="9,001; 8,000; 7,000; 6,000; 5,000; 4,000; 3,000; 4,000; 3,000; 2,000; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 2000; 3000; 4000; 5000; 6000; 7000; 8000; 9001" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  3 life cards.  HIT:  You may discard a card from your hand to search your Life Deck for a Styled Drill and place it into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -686,7 +686,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="3,500; 3,000; 2,500; 2,000; 1,500; 1,000; 800; 600; 400; 200; 0" />
+      <property name="Power Rating" value="0; 200; 400; 600; 800; 1000; 1500; 2000; 2500; 3000; 3500" />
       <property name="Text" value="[CONSTANT]:  When you perform a Styled attack you may destroy up to 2 cards from the top of your Life Deck.  That attack deals +X life cards.  X = the number of cards destroyed." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -697,7 +697,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="4,000; 3,600; 3,200; 2,800; 2,400; 2,000; 1,600; 1,200; 800; 400; 0" />
+      <property name="Power Rating" value="0; 400; 800; 1200; 1600; 2000; 2400; 2800; 3200; 3600; 4000" />
       <property name="Text" value="Energy attack costing 2 stages.  DAMAGE:  4 life cards.  The next time a card is discarded from a hand this combat, use a critical damage effect." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -708,7 +708,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="100,000,000; 10,000,000; 1,000,000; 500,000; 250,000; 100,000; 50,000; 25,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 100000; 250000; 500000; 1000000; 10000000; 100000000" />
       <property name="Text" value="POWER:  Destroy the top card of your Life Deck to draw a card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -719,7 +719,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="8,500; 7,000; 5,500; 4,500; 3,500; 2,200; 1,700; 1,000; 900; 0" />
+      <property name="Power Rating" value="8500; 7000; 5500; 4500; 3500; 2200; 1700; 1000; 900; 0" />
       <property name="Text" value="POWER:  Energy attack costing 1 stage.  DAMAGE:  3 life cards.  Rejuvenate 1." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -793,7 +793,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="94,000; 79,000; 64,000; 49,000; 34,000; 19,000; 9,000; 4,500; 900; 450; 0" />
+      <property name="Power Rating" value="0; 450; 900; 4500; 9000; 19000; 34000; 49000; 64000; 79000; 94000" />
       <property name="Text" value="[CONSTANT]:  When you stop an attack, you may raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1343,7 +1343,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="9,001; 8,000; 7,000; 6,000; 5,000; 4,000; 3,000; 4,000; 3,000; 2,000; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 2000; 3000; 4000; 5000; 6000; 7000; 8000; 9001" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  3 life cards.  HIT:  You may discard a card from your hand to search your Life Deck for a Styled Drill and place it into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1354,7 +1354,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="33,000; 29,000; 25,000; 21,000; 17,000; 13,000; 9,000; 5,000; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 5000; 9000; 13000; 17000; 21000; 25000; 29000; 33000" />
       <property name="Text" value="[CONSTANT]:  At the end of each combat, you may lower your MP a personality level and you may search your Life Deck or discard pile for a Drill and place it into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1365,7 +1365,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="900,000; 800,000; 700,000; 600,000; 500,000; 400,000; 300,000; 200,000; 100,000; 50,000; 0" />
+      <property name="Power Rating" value="0; 50000; 100000; 200000; 300000; 400000; 500000; 600000; 700000; 800000; 900000" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  5 life cards.  You may choose a Drill or Setup in your discard pile and place it into play.  HIT:  Rejuvenate up to 5 Drills from your discard pile." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1376,7 +1376,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,650,000; 1,500,000; 1,350,000; 1,200,000; 1,000,000; 800,000; 600,000; 400,000; 200,000; 100,000; 0" />
+      <property name="Power Rating" value="0; 100000; 200000; 400000; 600000; 800000; 1000000; 1200000; 1350000; 1500000; 1650000" />
       <property name="Text" value="POWER:  Search your Life Deck, discard pile, and Banished Zone for a total of 5 Drills and place them into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1387,7 +1387,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="3,500; 3,000; 2,500; 2,000; 1,500; 1,000; 800; 600; 400; 200; 0" />
+      <property name="Power Rating" value="0; 200; 400; 600; 800; 1000; 1500; 2000; 2500; 3000; 3500" />
       <property name="Text" value="[CONSTANT]:  When you perform a Styled attack, you may destroy up to 2 cards from the top of your Life Deck.  That attack deals +X life cards.  X = the number of cards destroyed." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1398,7 +1398,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="18,000; 16,000; 14,000; 12,000; 10,000; 8,000; 6,000; 4,000; 2,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 2000; 4000; 6000; 8000; 10000; 12000; 14000; 16000; 18000" />
       <property name="Text" value="[CONSTANT]:  Your Styled attacks deal +2 life cards of damage.  When you deal critical damage, you may Rejuvenate 1." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1409,7 +1409,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="400,000; 350,000; 300,000; 250,000; 200,000; 150,000; 100,000; 75,000; 7,500; 750; 0" />
+      <property name="Power Rating" value="0; 750; 7500; 75000; 100000; 150000; 200000; 250000; 300000; 350000; 400000" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  6 stages.  You may lower your anger any amount.  This attack deals +X life cards.  X = 2 times the amount lowered." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1420,7 +1420,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="525,000; 450,000; 375,000; 300,000; 225,000; 200,000; 125,000; 50,000; 5,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 5000; 50000; 125000; 200000; 225000; 300000; 375000; 450000; 525000" />
       <property name="Text" value="[CONSTANT]:  Your Styled attacks deal +3 life cards of damage.  When one of your effects raises your anger, you may shuffle 1 card with &quot;anger&quot; in the text box from your discard pile into your Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1431,7 +1431,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="4,000; 3,600; 3,200; 2,800; 2,400; 2,000; 1,600; 1,200; 800; 400; 0" />
+      <property name="Power Rating" value="0; 400; 800; 1200; 1600; 2000; 2400; 2800; 3200; 3600; 4000" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  4 life cards.  The next time a card is discarded from a hand this combat, use a critical damage effect and raise your anger 2 levels." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1442,7 +1442,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="21,000; 19,000; 17,000; 15,000; 13,000; 11,000; 9,000; 7,000; 5,000; 3,000; 0" />
+      <property name="Power Rating" value="0; 3000; 5000; 7000; 9000; 11000; 13000; 15000; 17000; 19000; 21000" />
       <property name="Text" value="POWER:  Energy attack costing 3 stages.  DAMAGE:  4 life cards.  HIT:  Your opponent discards a card from his hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1453,7 +1453,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="375,000; 300,000; 225,000; 150,000; 75,000; 50,000; 25,000; 10,000; 5,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 5000; 10000; 25000; 50000; 75000; 150000; 225000; 300000; 375000" />
       <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  9 - X life cards.  X = the number of cards in your opponent's hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1464,7 +1464,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="6" />
-      <property name="Power Rating" value="500,000; 400,000; 300,000; 200,000; 100,000; 75,000; 50,000; 25,000; 10,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 10000; 25000; 50000; 75000; 100000; 200000; 300000; 400000; 500000" />
       <property name="Text" value="[CONSTANT]:  Your first Styled attack each turn cannot be stopped." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1475,7 +1475,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="94,000; 79,000; 64,000; 49,000; 34,000; 19,000; 9,000; 4,500; 900; 450; 0" />
+      <property name="Power Rating" value="0; 450; 900; 4500; 9000; 19000; 34000; 49000; 64000; 79000; 94000" />
       <property name="Text" value="[CONSTANT]:  When you stop an attack, you may raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1486,7 +1486,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="599,000; 399,000; 199,000; 99,000; 79,000; 59,000; 39,000; 19,000; 9,000; 900; 0" />
+      <property name="Power Rating" value="0; 900; 9000; 19000; 39000; 59000; 79000; 99000; 199000; 399000; 599000" />
       <property name="Text" value="POWER:  Discard a card from your hand to perform the last attack your opponent used this combat.  That attack deals an additional +2 stages of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1497,7 +1497,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="1,000,000; 700,000; 400,000; 200,000; 100,000; 50,000; 25,000; 10,000; 5,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 5000; 10000; 25000; 50000; 100000; 200000; 400000; 700000; 1000000" />
       <property name="Text" value="[CONSTANT]:  Your attacks deal +3 stages of damage and you may also use your Level 1 CONSTANT powers." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1508,7 +1508,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,400,000; 1,200,000; 1,000,000; 800,000; 600,000; 400,000; 200,000; 100,000; 50,000; 25,000; 0" />
+      <property name="Power Rating" value="0; 25000; 50000; 100000; 200000; 400000; 600000; 800000; 1000000; 1200000; 1400000" />
       <property name="Text" value="POWER:  Destroy the top 4 cards of your opponent's Life Deck.  Search your Life Deck for a Frieza Named card and place it in your hand.  [CONSTANT]:  You may also use your Level 2 Powers." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1519,7 +1519,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="8,500; 7,000; 5,500; 4,500; 3,500; 2,200; 1,700; 1,100; 900; 0" />
+      <property name="Power Rating" value="0; 900; 1100; 1300; 1700; 2200; 3500; 4500; 5500; 7000; 8500" />
       <property name="Text" value="POWER:  Energy attack costing 1 stage.  DAMAGE:  3 life cards.  Rejuvenate 1." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1530,7 +1530,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="23,000; 20,000; 17,000; 14,000; 11,000; 8,000; 5,000; 2,000; 1,000; 500; 0" />
+      <property name="Power Rating" value="0; 500; 1000; 2000; 5000; 8000; 11000; 14000; 17000; 20000; 23000" />
       <property name="Text" value="POWER:  Discard a card from your hand to Rejuvenate 2 and your opponent destroys the top 2 cards of his Life Deck.  If you discarded a Styled card, you may draw a card and use a critical damage effect." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1541,7 +1541,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="600,000; 500,000; 400,000; 300,000; 200,000; 150,000; 100,000; 50,000; 10,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 10000; 50000; 100000; 150000; 200000; 300000; 400000; 500000; 600000" />
       <property name="Text" value="[CONSTANT]:  All of your attacks deal +2 life cards of damage.  Once per Combat when you deal critical damage, you may search your Life Deck for a Dragon Ball and put it into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1552,7 +1552,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="750,000; 650,000; 550,000; 450,000; 350,000; 250,000; 150,000; 100,000; 50,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 50000; 100000; 150000; 250000; 350000; 450000; 550000; 650000; 750000" />
       <property name="Text" value="[CONSTANT]:  Your opponent needs to deal 7 or more life cards to activate critical damage.  POWER:  Energy attack costing 2 stages.  DAMAGE:  7 life cards.  HIT:  Rejuvenate X.  X = the  number of Dragon Balls in play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -2976,7 +2976,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="1,100,00; 900,000; 700,00; 500,00; 300,00; 100,00; 50,000; 25,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 10000; 30000; 50000; 70000; 900000; 110000" />
       <property name="Text" value="[CONSTANT]:  When entering combat, look at the top 6 cards of your Life Deck and put them back in any order.  Draw a card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -2987,7 +2987,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="1,600,000; 1,500,000; 1,400,000; 1,200,000; 1,000,000; 800,000; 600,000; 400,000; 200,000; 100,000; 0" />
+      <property name="Power Rating" value="0; 100000; 200000; 400000; 600000; 800000; 1000000; 1200000; 1400000; 1500000; 1600000" />
       <property name="Text" value="[CONSTANT]:  When entering combat, look at the top 6 cards of a player's Life Deck and put them back in any order." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -2998,7 +2998,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="175,000; 150,000; 125,000; 100,000; 80,000; 60,000; 40,000; 20,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 20000; 40000; 60000; 80000; 100000; 125000; 150000; 175000" />
       <property name="Text" value="[CONSTANT]:  Your &quot;Ginyu Force&quot; Allies may mack actions regardless of your MP's power stage and they cannot be discarded.  All of your attacks deal +2 life cards of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3009,7 +3009,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="10; 9; 8; 7; 6; 5; 4; 3; 2; 1; 0" />
+      <property name="Power Rating" value="0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10" />
       <property name="Text" value="[CONSTANT]:  Your Allies may make actions regardless of your MP's power stage and they cannot be discarded.  All of your attacks deal +X life cards of damage.  X = the number of Allies you have in play when you perform that attack." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3020,7 +3020,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="20; 18; 16; 14; 12; 10; 8; 6; 4; 2; 0" />
+      <property name="Power Rating" value="0; 2; 4; 6; 8; 10; 12; 14; 16; 18; 20" />
       <property name="Text" value="(Heroes only.)  [CONSTANT]:  When Bulma enters play, attach a card from any discard pile to her.  Cards with that title cannot be played." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3031,7 +3031,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="50; 45; 40; 35; 30; 25; 20; 15; 10; 5; 0" />
+      <property name="Power Rating" value="0; 5; 10; 15; 20; 25; 30; 35; 40; 45; 50" />
       <property name="Text" value="(Heroes only.  If your MP is Goku - Gohan - or Goten, you may use this power regardless of your MP's power stage.)  POWER:  Stops a physical attack." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3042,7 +3042,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="95,000; 90,000; 85,000; 75,000; 65,000; 55,000; 40,000; 25,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 10000; 25000; 40000; 55000; 65000; 75000; 85000; 90000; 95000" />
       <property name="Text" value="(Heroes only.)  POWER:  Energy attack costing 1 stage.  DAMAGE:  3 life cards.  HIT:  Shuffle a Setup, Drill or Ally in play into its owner's Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3053,7 +3053,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="64,000; 32,000; 16,000; 8,000; 4,000; 2,000; 1,000; 500; 250; 125; 0" />
+      <property name="Power Rating" value="0; 125; 250; 500; 1000; 2000; 4000; 8000; 16000; 32000; 64000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  Your attacks deal +1 stage of damage.  If your MP is &quot;Captain Ginyu&quot;, your attacks deal +2 stages of damage instead." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3064,7 +3064,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="65,000; 60,000; 55,000; 45,000; 35,000; 25,000; 15,000; 5,000; 2,500; 1,250; 0" />
+      <property name="Power Rating" value="0; 1250; 2500; 5000; 15000; 25000; 35000; 45000; 55000; 60000; 65000" />
       <property name="Text" value="(Villains only.)  POWER:  Energy attack costing 2 stages.  DAMAGE:  5 life cards.  Raise a player's anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3472,7 +3472,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="150,000; 125,000; 100,000; 75,000; 50,000; 25,000; 10,000; 5,000; 1,000; 500, 0" />
+      <property name="Power Rating" value="150000; 125000; 100000; 75000; 50000; 25000; 10000; 5000; 1000; 500, 0" />
       <property name="Text" value="[CONSTANT]:  Your attacks that raise your anger deal +3 power stages and +3 life cards of damage." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3483,7 +3483,7 @@
       <property name="Rarity" value="Promo" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="10,000; 8,000; 6,000; 5,000; 4,000; 3,000; 2,000; 1,000; 500; 250; 0" />
+      <property name="Power Rating" value="0; 250; 500; 1000; 2000; 3000; 4000; 5000; 6000; 8000; 10000" />
       <property name="Text" value="[CONSTANT]:  Your attacks gain &quot;HIT:  Raise your anger 1 level.&quot;" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3494,7 +3494,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="10,000; 8,000; 6,000; 5,000; 4,000; 3,000; 2,000; 1,000; 500; 250; 0" />
+      <property name="Power Rating" value="0; 250; 500; 1000; 2000; 3000; 4000; 5000; 6000; 8000; 10000" />
       <property name="Text" value="[CONSTANT]:  Your attacks gain &quot;HIT:  Raise your anger 1 level.&quot;" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3505,7 +3505,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="800,000; 700,000; 600,000; 500,000; 400,000; 300,000; 200,000; 100,000; 10,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 10000; 100000; 200000; 300000; 400000; 500000; 600000; 700000; 800000" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  AT +6 stages.  Lower your anger 1 level to draw a card." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -3516,7 +3516,7 @@
       <property name="Rarity" value="Starter" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="25,000; 20,000; 15,000; 10,000; 5,000; 4,000; 3,000; 2,000; 1,000; 500, 0" />
+      <property name="Power Rating" value="25000; 20000; 15000; 10000; 5000; 4000; 3000; 2000; 1000; 500, 0" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  4 stages.  HIT:  Your attacks that raise your anger level deal +1 stage and +1 life card of damage this combat." />
       <property name="Limit per Deck" value="1" />
     </card>

--- a/sets/7c692d00-282d-408b-8c5d-1dcc9cf661d1/set.xml
+++ b/sets/7c692d00-282d-408b-8c5d-1dcc9cf661d1/set.xml
@@ -13,7 +13,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="22,000; 18,000; 14,000; 10,000; 6,000; 5,000; 4,000; 3,000; 2,000; 1,000; 0" />
+      <property name="Power Rating" value="0; 1000; 2000; 3000; 4000; 5000; 6000; 10000; 14000; 18000; 22000" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  AT +2 life cards.  If this attack is stopped, destroy the top card of your opponent&apos;s Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -24,7 +24,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="40,000; 36,000; 32,000; 28,000; 24,000; 20,000; 16,000; 12,000; 8,000; 4,000; 0" />
+      <property name="Power Rating" value="0; 4000; 8000; 12000; 16000; 20000; 24000; 28000; 32000; 36000; 40000" />
       <property name="Text" value="[CONSTANT]:  Whenever your opponent stops one of your attacks, he destroys the top 2 cards of his Life Deck.  After your opponent takes damage from one of your attacks, he banishes the top X cards of his Life Deck.  X = the number of times he used Endurance" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -35,7 +35,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="8,750; 8,000; 7,250; 6,500; 5,750; 5,000; 4,250; 3,500; 2,750; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 2750; 3500; 4250; 5000; 5750; 6500; 7250; 8000; 8750" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  3 stages.  Destroy one of your opponent&apos;s Allies." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -46,7 +46,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="9,000; 8,500; 8,000; 7,500; 7,000; 6,500; 6,000; 5,500; 5,000; 4,500; 0" />
+      <property name="Power Rating" value="0; 4500; 5000; 5500; 6000; 6500; 7000; 7500; 8000; 8500; 9000" />
       <property name="Text" value="[CONSTANT]:  If you changed levels this combat, your opponent&apos;s personalities lose 2 stages whenever you perform an attack.  Otherwise, your opponent&apos;s MP loses 1 stage whenever you perform an attack." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -57,7 +57,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="8,700; 7,800; 6,900; 6,000; 5,100; 4,200; 3,300; 2,400; 1,500; 600; 0" />
+      <property name="Power Rating" value="0; 600; 1500; 2400; 3300; 4200; 5100; 6000; 6900; 7800; 8700" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  1 life card.  Reveal the top 2 cards of your Life Deck.  Place 1 into your hand and banish the other.  Raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -68,7 +68,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="13,000; 12,500; 12,000; 11,500; 11,000; 10,500; 10,000; 9,500; 9,000; 8,500; 0" />
+      <property name="Power Rating" value="0; 8500; 9000; 9500; 10000; 10500; 11000; 11500; 12000; 12500; 13000" />
       <property name="Text" value="[CONSTANT]:  Whenever one of your Setup or Drills enters play, destroy the top card of your opponent&apos;s Life Deck.  Whenever one of your Setups or Drills enters play during combat, raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -79,7 +79,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="2" />
-      <property name="Power Rating" value="3,800; 3,400; 3,000; 2,600; 2,200; 1,800; 1,600; 1,400; 1,000; 600; 200;0" />
+      <property name="Power Rating" value="3800; 0; 200; 600; 1000; 1400; 1600; 1800; 2200; 2600; 3000; 3400" />
       <property name="Text" value="POWER:  Banish the top card of your Life Deck to search your Life Deck for a Named card and place it into your hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -90,7 +90,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="3" />
-      <property name="Power Rating" value="11,000; 10,000; 9,000; 8,000; 7,000; 6,000; 5,000; 4,000; 3,000; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 3000; 4000; 5000; 6000; 7000; 8000; 9000; 10000; 11000" />
       <property name="Text" value="[CONSTANT]:  Your attacks deal +1 life card of damage.  Once per combat after using a critical damage effect, you may search your discard pile for a non-Styled card and Rejuvenate it." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -101,7 +101,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="75,000; 65,000; 55,000; 45,000; 35,000; 25,000; 15,000; 5,000; 2,500; 1,250; 0" />
+      <property name="Power Rating" value="0; 1250; 2500; 5000; 15000; 25000; 35000; 45000; 55000; 65000; 75000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  Your opponent plays with his hand revealed." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -112,7 +112,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="35,000; 30,000; 25,000; 20,000; 15,000; 10,000; 8,000; 6,000; 4,000; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 4000; 6000; 8000; 10000; 15000; 20000; 25000; 30000; 35000" />
       <property name="Text" value="(Villains only.)  POWER:  Capture a Dragon Ball.  Banish &quot;Dodoria&quot; at the beginning of the next action this combat." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -123,7 +123,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="85,000; 80,000; 75,000; 70,000; 65,000; 60,000; 55,000; 50,000; 45,000; 40,000; 0" />
+      <property name="Power Rating" value="0; 40000; 45000; 50000; 55000; 60000; 65000; 70000; 75000; 80000; 85000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  Life card damage from attacks is banished." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -134,7 +134,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="65,000; 60,000; 55,000; 50,000; 40,000; 35,000; 30,000; 25,000; 20,000; 15,000; 0" />
+      <property name="Power Rating" value="0; 15000; 20000; 25000; 30000; 35000; 40000; 50000; 55000; 60000; 65000" />
       <property name="Text" value="(Heroes only.)  [CONSTANT]:  Whenever a player raises his anger, change that amount to 1." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -145,7 +145,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="70,000; 60,000; 50,000; 40,000; 30,000; 20,000; 15,000; 10,000; 5,000; 2,500; 0" />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 15000; 20000; 30000; 40000; 50000; 60000; 70000" />
       <property name="Text" value="(Heroes only.)  [CONSTANT]:  One per turn at the start of your Rejuvenation Step, choose a Drill and destory it." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -156,7 +156,7 @@
       <property name="Rarity" value="Common" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="45,000; 40,000; 35,000; 30,000; 25,000; 20,000; 15,000; 10,000; 5,000; 2,500; 0" />
+      <property name="Power Rating" value="0; 2500; 5000; 10000; 15000; 20000; 25000; 30000; 35000; 40000; 45000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  After taking damage from a physical attack, you may raise a player&apos;s anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1113,7 +1113,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="125,000; 120,000; 115,000; 110,000; 105,000; 95,000; 90,000; 85,000; 80,000; 0" />
+      <property name="Power Rating" value="125000; 120000; 115000; 110000; 105000; 95000; 90000; 85000; 80000; 0" />
       <property name="Text" value="[CONSTANT]:  Your attacks deal +3 stages of damage.  POWER:  You may return a Dragon Ball in play to its owner&apos;s hand or you may choose a Dragon Ball in your hand and place it into play.  Raise your anger 1 level." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1124,7 +1124,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="150,000; 145,000; 140,000; 135,000; 130,000; 125,000; 120,000; 115,000; 110,000; 105,000; 0" />
+      <property name="Power Rating" value="0; 105000; 110000; 115000; 120000; 125000; 130000; 135000; 140000; 145000; 150000" />
       <property name="Text" value="[CONSTANT]:  Your maximum hand size is +1 during the Discard Step.  POWER:  Physical attack.  DAMAGE:  7 stages.  HIT:  You may use the immediate effects of a Dragon Ball in play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1135,7 +1135,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="14,000; 13,000; 12,000; 11,000; 10,000; 9,000; 8,000; 7,000; 6,000; 5,000; 0" />
+      <property name="Power Rating" value="0; 5000; 6000; 7000; 8000; 9000; 10000; 11000; 12000; 13000; 14000" />
       <property name="Text" value="POWER:  Physical attack.  DAMAGE:  7 stages.  HIT:  Banish a Drill or Ally." />
       <property name="Limit per Deck" value="3" />
     </card>
@@ -1146,7 +1146,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="24,000; 22,000; 20,000; 18,000; 16,000; 14,000; 12,000; 10,000; 8,000; 6,000; 0" />
+      <property name="Power Rating" value="0; 6000; 8000; 10000; 12000; 14000; 16000; 18000; 20000; 22000; 24000" />
       <property name="Text" value="[CONSTANT]:  Your attacks deal +4 stages of damage.  If your opponent&apos;s MP&apos;s power level is 0, your attacks cannot have their damage prevented." />
       <property name="Limit per Deck" value="3" />
     </card>
@@ -1157,7 +1157,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="17,000; 16,000; 15,000; 14,000; 13,000; 12,000; 11,000; 10,000; 9,000; 8,000; 0" />
+      <property name="Power Rating" value="0; 8000; 9000; 10000; 11000; 12000; 13000; 14000; 15000; 16000; 17000" />
       <property name="Text" value="[INSTANT] POWER:  Use when entering combat.  Your opponent discards a random card from his hand." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1168,7 +1168,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="22,000; 21,000; 20,000; 19,000; 18,000; 17,000; 16,000; 15,000; 14,000; 13,000; 0" />
+      <property name="Power Rating" value="0; 13000; 14000; 15000; 16000; 17000; 18000; 19000; 20000; 21000; 22000" />
       <property name="Text" value="[CONSTANT]:  Whenver one of your Setups or Drills enters play, choose a card in your discard pile and Rejuvenate it.  The first time you use a critical damage effect each combat, you may search your Life Deck or discard pile for a Setup or Drill and place i" />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1179,7 +1179,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="4" />
-      <property name="Power Rating" value="105,000; 100,000; 95,000; 90,000; 85,000; 80,000; 75,000; 70,000; 65,000; 60,000; 0" />
+      <property name="Power Rating" value="0; 60000; 65000; 70000; 75000; 80000; 85000; 90000; 95000; 100000; 105000" />
       <property name="Text" value="(You cannot win by MPPV if you raise your anger with this effect.)  POWER:  Energy attack.  DAMAGE:  5 life cards.  You may banish 8 cards from your discard pile.  If you do, raise your anger 6 levels." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1190,7 +1190,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Personality" />
       <property name="PUR" value="5" />
-      <property name="Power Rating" value="275,000; 250,000; 225,000; 200,000; 175,000; 150,000; 125,000; 100,000; 75,000; 50,000; 0" />
+      <property name="Power Rating" value="0; 50000; 75000; 100000; 125000; 150000; 175000; 200000; 225000; 250000; 275000" />
       <property name="Text" value="[CONSTANT]:  The first attack you play each combat stays in play to be used a second time that combat." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1201,7 +1201,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="90,000; 75,000; 60,000; 55,000; 40,000; 25, 000; 20,000; 15,000; 10,000; 5,000; 0" />
+      <property name="Power Rating" value="90000; 75000; 60000; 55000; 40000; 25, 000; 20000; 15000; 10000; 5000; 0" />
       <property name="Text" value="(Heroes only.)  POWER:  Search your Life Deck for a Styled Drill and place it into play." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1212,7 +1212,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="80,000; 70,000; 60,000; 50,000; 40,000; 30,000; 20,000; 10,000; 5,000; 2,500;" />
+      <property name="Power Rating" value="80000; 70000; 60000; 50000; 40000; 30000; 20000; 10000; 5000; 2500;" />
       <property name="Text" value="(Heroes only.  If your MP is Gohan, you may use this power regardless of your MP&apos;s power stage.)  POWER:  Stops an energy attack." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1223,7 +1223,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="95,000; 85,000; 75,000; 65,000; 55,000; 45,000; 35,000; 25,000; 20,000; 15,000; 0" />
+      <property name="Power Rating" value="0; 15000; 20000; 25000; 35000; 45000; 55000; 65000; 75000; 85000; 95000" />
       <property name="Text" value="(Heroes only.)  [INSTANT] POWER:  Use when entering combat.  Look at the top card of a player&apos;s Life Deck.  You may place that card at the bottom of that player&apos;s Life Deck." />
       <property name="Limit per Deck" value="1" />
     </card>
@@ -1234,7 +1234,7 @@
       <property name="Rarity" value="Uncommon" />
       <property name="Type" value="Ally" />
       <property name="PUR" value="1" />
-      <property name="Power Rating" value="20,000; 18,000; 16,000; 14,000; 12,000; 10,000; 8,000; 6,000; 4,000; 2,000; 0" />
+      <property name="Power Rating" value="0; 2000; 4000; 6000; 8000; 10000; 12000; 14000; 16000; 18000; 20000" />
       <property name="Text" value="(Villains only.)  [CONSTANT]:  Your physical attacks deal +1 stage of damage.  If Nappa is your MP, your physical attacks deal +2 stages of damage instead.)" />
       <property name="Limit per Deck" value="1" />
     </card>

--- a/sets/839cfa4d-1d3a-4667-9929-cf6a289fd33b/set.xml
+++ b/sets/839cfa4d-1d3a-4667-9929-cf6a289fd33b/set.xml
@@ -216,7 +216,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 5,000; 10,000; 15,000; 25,000; 200,000; 400,000; 650,000; 800,000; 1,000,000" />
+<property name="Power Rating" value="0; 1000; 5000; 10000; 15000; 25000; 200000; 400000; 650000; 800000; 1000000" />
 <property name="Text" value="(You cannot win by MPPV if you advance a personality level with this INSTANT Power.)  CONSTANT POWER:  Your first successful attack each combat gains HIT: Destroy an opponent's Ally and raise your anger 1 level.  INSTANT POWER: Use when entering combat.  Search your Life Deck for 7 Named cards and banish them to advance a level.  POWER: Energy attack.  DAMAGE: 2 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -228,7 +228,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 9,999, 60,000; 80,000; 100,000; 150,000; 250,000; 300,000; 450,000; 500,000; 650,000" />
+<property name="Power Rating" value="0; 9999, 60000; 80000; 100000; 150000; 250000; 300000; 450000; 500000; 650000" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal +1 life card of damage.  At the start of each turn, you may look at the top 2 cards of your Life Deck and place any number of them on the top or bottom of your Life Deck.  POWER: Energy Attack.  Rejuvenate a card with Android in the title from your discard pile to use a critical daamge effect.  DAMAGE: 0 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -240,7 +240,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 500; 1,000; 5,000; 10,000; 25,000; 50,000; 100,000; 150,000; 200,000; 250,000" />
+<property name="Power Rating" value="0; 500; 1000; 5000; 10000; 25000; 50000; 100000; 150000; 200000; 250000" />
 <property name="Text" value="(Your Life Deck may include non-Personality cards that are Heroes only.)  POWER: Physical attack.  Raise or lower a player's anger 2 levels.  You may Rejuvenate a card that is Alignment-restricted from your discard pile.  DAMAGE: 2 life cards.  HIT: If you have changed levels this combat, search your discard pile for a card that is Alignment-restricted and place it into your hand." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -252,7 +252,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Villain" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,500; 5,000; 10,000; 15,000; 25,000; 50,000; 60,000; 80,000; 90,000; 100,000" />
+<property name="Power Rating" value="0; 1500; 5000; 10000; 15000; 25000; 50000; 60000; 80000; 90000; 100000" />
 <property name="Text" value="INSTANT POWER: Use after your opponent draws any number of cards from a card effect.  Discard a card at random from your opponent's hand.  POWER: Physical attack.  Lower your opponent's anger 1 level.  DAMAGE: 4 stages.  HIT: Search your Life Deck or discard pile for Android 17's Van and place it into play." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -264,7 +264,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Villain Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 500; 1,000; 5,000; 10,000; 25,000; 50,000; 100,000; 200,000; 300,000; 500,000" />
+<property name="Power Rating" value="0; 500; 1000; 5000; 10000; 25000; 50000; 100000; 200000; 300000; 500000" />
 <property name="Text" value="(This card is considered Named for your effects.  If your MP is Frieza or Cooler, you may use this Power regardless of your MP's power stages.)  CONTINUOUS POWER: If your MP is Frieza, your opponent cannot use effects that lower your MP 1 or more levels.  POWER: Physical attack.  DAMAGE: 1 life card.  HIT: Rejuvenate a Named card in your discard pile or Banished Zone." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -276,7 +276,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 1,500; 3,000; 9,000; 15,000; 100,000; 200,000; 400,000; 600,000; 800,000; 1,000,000" />
+<property name="Power Rating" value="0; 1500; 3000; 9000; 15000; 100000; 200000; 400000; 600000; 800000; 1000000" />
 <property name="Text" value="INSTANT POWER: Use when an event is played as an action.  Banish the top card of your Life Deck to cancel the effects of that card.  POWER: Energy attack.  Search your discard pile for a card and Rejuvenate it.  DAMAGE: 1 life card." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -288,7 +288,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 9,900; 30,000; 50,000; 80,000; 100,000; 300,000; 500,000; 700,000; 1,000,000; 1,500,000" />
+<property name="Power Rating" value="0; 9900; 30000; 50000; 80000; 100000; 300000; 500000; 700000; 1000000; 1500000" />
 <property name="Text" value="CONTINUOUS POWER: Whenever your opponent plays an Event, Rejuvenate 1 and banish the top card of their Life Deck.  POWER: Rejuvenate 3.  You may discard a card from your hand.  If you do, your opponent's next attack this combat deals no damage." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -300,7 +300,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 10,000; 75,000; 150,000; 250,000; 500,000; 700,000; 1,000,000; 1,300,000; 1,600,000; 1,800,000" />
+<property name="Power Rating" value="0; 10000; 75000; 150000; 250000; 500000; 700000; 1000000; 1300000; 1600000; 1800000" />
 <property name="Text" value="CONTINUOUS POWER: Whenever your opponent plays an Event, banish the top 2 cards of their Life Deck.  POWER: Energy Attack.  Rejuvenate 2.  If your opponent has played an Event this combat, this attack deals +5 stages of damage.  DAMAGE: 5 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -312,7 +312,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 15,000; 30,000; 50,000; 100,000; 300,000; 600,000; 1,500;000, 1,700,000; 2,000,000; 2,500,000" />
+<property name="Power Rating" value="0; 15000; 30000; 50000; 100000; 300000; 600000; 1500000; 1700000; 2000000; 2500000" />
 <property name="Text" value="CONTINUOUS POWER: Whenever your opponent plays an Event, Rejuvenate 5.  POWER: Energy attack.  This attack can only be stopped by Energy Combat cards.  DAMAGE: 1 life card.  HIT: Banish the bottom 5 cards of your opponent's Life Deck." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -324,7 +324,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 15,000; 20,000; 30,000; 50,000; 70,000; 80,000; 100,000; 200,000; 300,000" />
+<property name="Power Rating" value="0; 1000; 15000; 20000; 30000; 50000; 70000; 80000; 100000; 200000; 300000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent's attacks deal -1 life card of damage.  POWER: Physical attack.  Choose a personality in play.  It loses all effects this turn.  You may set both players' anger level to 2.  DAMAGE: 2 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -336,7 +336,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 9,000; 15,000; 30,000; 50,000; 200,000; 400,000; 500,000; 600,000; 800,000; 1,000,000" />
+<property name="Power Rating" value="0; 9000; 15000; 30000; 50000; 200000; 400000; 500000; 600000; 800000; 1000000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent's attacks deal -1 life card of damage.  POWER: Physical attack.  Lower your opponent's anger 2 levels.  If your opponent has used a non-CONTINUOUS personality Power this this turn, damage from this attack cannot be prevented.  DAMAGE: 6 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -348,7 +348,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 10,000; 20,000; 30,000; 50,000; 60,000; 80,000; 1,000,000; 1,200,000; 1,300,000; 1,500,000" />
+<property name="Power Rating" value="0; 10000; 20000; 30000; 50000; 60000; 80000; 1000000; 1200000; 1300000; 1500000" />
 <property name="Text" value="CONTINUOUS POWER: Your opponent's attacks deal -1 life card of damage.  POWER: PHysical attack.  Rejuvenate 2.  If your opponent has used a non-CONTINUOUS personality Power this turn, you may use this attack a second time this combat.  DAMAGE: 5 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -360,7 +360,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 25,000; 50,000; 200,000; 400,000; 700,000; 1,100,000; 1,300,000; 1,400,000; 1,500,000; 1,850,000" />
+<property name="Power Rating" value="0; 25000; 50000; 200000; 400000; 700000; 1100000; 1300000; 1400000; 1500000; 1850000" />
 <property name="Text" value="(At the end of your Planning Step, if you control no Allies, search your Life Deck for an Ally with Bubbles or Gregory in the title and play it.)  INSTANT POWER: Use when entering combat.  Choose a Bubbles or Gregory Ally in play.  That Ally can make actions regardless of your MP's power stage this combat.  Raise your anger 1 level.  POWER: Draw a card.  Discard a card from your hand." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -372,7 +372,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 100; 500; 700; 800; 900; 1,000; 1,250; 1,500; 2,500; 3,000" />
+<property name="Power Rating" value="0; 100; 500; 700; 800; 900; 1000; 1250; 1500; 2500; 3000" />
 <property name="Text" value="(At the end of your Planning Step, if you control no Allies, search your Life Deck for an Ally with Bubbles or Gregory in the title and play it.)  INSTANT POWER: Use when entering combat.  Choose a Bubbles or Gregory Ally in play.  That Ally can make actions regardless of your MP's power stage this combat.  Raise your anger 1 level.  POWER: Draw a card.  Discard a card from your hand." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -384,7 +384,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 300; 600; 700; 1,000; 1,500; 2,000; 3,250; 3,500; 4,500; 5,000" />
+<property name="Power Rating" value="0; 300; 600; 700; 1000; 1500; 2000; 3250; 3500; 4500; 5000" />
 <property name="Text" value="(Your Bubbles and Gregory Allies can make actions regardless of your MP's power stage.)  POWER: Rejuvenate 2.  Raise an Ally to its highest power stage.  For the remainder of combat, attacks performed by that Ally deal +3 life cards of damage." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -396,7 +396,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 500; 1,000; 1,700; 2,000; 2,500; 3,000; 3,250; 4,500; 5,500; 5,000" />
+<property name="Power Rating" value="0; 500; 1000; 1700; 2000; 2500; 3000; 3250; 4500; 5500; 5000" />
 <property name="Text" value="(Your Bubbles and Gregory Allies can make actions regardless of your MP's power stage.)  INSTANT POWER: Use when entering combat.  Search your Life Deck for an Ally with Bubbles or Gregory in the title and play it.  POWER: Physical attack.  If this attack is stopped and you control a Bubbles and Gregory Ally, destroy the top 3 cards of your opponent's Life Deck.  DAMAGE: 6 life cards." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -408,7 +408,7 @@
 <property name="Rarity" value="Starter" />
 <property name="Type" value="Hero" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 1,500; 2,000; 3,700; 4,000; 4,500; 6,000; 6,250; 6,500; 7,000; 8,000" />
+<property name="Power Rating" value="0; 1500; 2000; 3700; 4000; 4500; 6000; 6250; 6500; 7000; 8000" />
 <property name="Text" value="(When one of your Allies would leave play, you may choose to have it stay in play.  Your Allies without CONTINUOUS Powers can make actions regardless of your MP's power stage.)  POWER: Physical attack.  DAMAGE: 5 life cards.  HIT: For the remainder of combat, attacks performed by your Allies deal +5 life cards of damage." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />
@@ -660,7 +660,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Hero Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 2,000; 5,000; 7,000; 9,000; 10,000; 15,000; 40,000; 60,000; 100,000; 200,000" />
+<property name="Power Rating" value="0; 2000; 5000; 7000; 9000; 10000; 15000; 40000; 60000; 100000; 200000" />
 <property name="Text" value="(If your MP is Pikkon, you may use this power regardless of your MP's power stage.)  SHIELD POWER: Prevent all damage from a physical attack.  Rejuvenate 1." />
 <property name="Limit per Deck" value="1" />
 <property name="Endurance" value="0" />

--- a/sets/cf028ea5-d40a-42c4-a252-33a4579ac1bf/set.xml
+++ b/sets/cf028ea5-d40a-42c4-a252-33a4579ac1bf/set.xml
@@ -586,7 +586,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 5,000; 10,000; 50,000; 100,000; 150,000; 300,000; 500,000; 800,000; 1,200,000; 1,600,000" />
+<property name="Power Rating" value="0; 5000; 10000; 50000; 100000; 150000; 300000; 500000; 800000; 1200000; 1600000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="1" />
 </card>
@@ -599,7 +599,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 500; 1,000; 3,000; 5,000; 10,000; 25,000; 50,000; 200,000; 666,000; 800,000" />
+<property name="Power Rating" value="0; 500; 1000; 3000; 5000; 10000; 25000; 50000; 200000; 666000; 800000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="1" />
 </card>
@@ -612,7 +612,7 @@
 <property name="Traits" value="Alien, Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="0; 100; 500; 700; 1,000; 2,000; 5,000; 15,000; 25,000; 50,000; 100,000" />
+<property name="Power Rating" value="0; 100; 500; 700; 1000; 2000; 5000; 15000; 25000; 50000; 100000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="1" />
 </card>
@@ -638,7 +638,7 @@
 <property name="Traits" value="Alien, Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 500; 700; 1,000; 2,000; 3,000; 10,000; 35,000; 75,000; 150,000; 200,000" />
+<property name="Power Rating" value="0; 500; 700; 1000; 2000; 3000; 10000; 35000; 75000; 150000; 200000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="1" />
 </card>
@@ -664,7 +664,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 5; 10; 25; 50; 100; 200; 400; 600; 800; 1,0000" />
+<property name="Power Rating" value="0; 5; 10; 25; 50; 100; 200; 400; 600; 800; 10000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>
@@ -677,7 +677,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 100; 250; 500; 700; 900; 1,000; 1,500; 2,000; 2,250; 2,500" />
+<property name="Power Rating" value="0; 100; 250; 500; 700; 900; 1000; 1500; 2000; 2250; 2500" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="2" />
 </card>
@@ -690,7 +690,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 100; 200; 300; 400; 700; 1,000; 1,500; 2,000; 2,500; 3,000" />
+<property name="Power Rating" value="0; 100; 200; 300; 400; 700; 1000; 1500; 2000; 2500; 3000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="3" />
 </card>
@@ -703,7 +703,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 100; 400; 500; 600; 1,500; 1,700; 2,500; 3,000; 3,500; 4,000" />
+<property name="Power Rating" value="0; 100; 400; 500; 600; 1500; 1700; 2500; 3000; 3500; 4000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="4" />
 </card>
@@ -716,7 +716,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 5,000; 25,000; 50,000; 100,000; 300,000; 500,000; 800,000; 1,000,000; 1,500,000; 2,000,000" />
+<property name="Power Rating" value="0; 5000; 25000; 50000; 100000; 300000; 500000; 800000; 1000000; 1500000; 2000000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>
@@ -729,7 +729,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 30,000; 60,000; 200,000; 400,000; 600,000; 800,000; 1,200,000; 1,600,000; 2,300,000; 3,000,000" />
+<property name="Power Rating" value="0; 30000; 60000; 200000; 400000; 600000; 800000; 1200000; 1600000; 2300000; 3000000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="2" />
 </card>
@@ -742,7 +742,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 40,000; 90,000; 300,000; 700,000; 900,000; 1,300,000; 1,700,000; 2,400,000; 3,300,000; 4,000,000" />
+<property name="Power Rating" value="0; 40000; 90000; 300000; 700000; 900000; 1300000; 1700000; 2400000; 3300000; 4000000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="3" />
 </card>
@@ -755,7 +755,7 @@
 <property name="Traits" value="Majin" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 50,000; 100,000; 300,000; 500,000; 700,000; 1,000,000; 2,000,000; 3,000,000; 4,000,000; 5,000,000" />
+<property name="Power Rating" value="0; 50000; 100000; 300000; 500000; 700000; 1000000; 2000000; 3000000; 4000000; 5000000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="4" />
 </card>
@@ -768,7 +768,7 @@
 <property name="Traits" value="Majin, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="0; 4,000; 7,000; 10,000; 20,000; 45,000; 90,000; 250,000; 550,000; 1,100,000; 1,600,000" />
+<property name="Power Rating" value="0; 4000; 7000; 10000; 20000; 45000; 90000; 250000; 550000; 1100000; 1600000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>
@@ -781,7 +781,7 @@
 <property name="Traits" value="Majin, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="0; 1,000; 10,000; 25,000; 50,000; 90,000; 150,000; 500,000; 900,000; 1,500,000; 2,200,000" />
+<property name="Power Rating" value="0; 1000; 10000; 25000; 50000; 90000; 150000; 500000; 900000; 1500000; 2200000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="2" />
 </card>
@@ -794,7 +794,7 @@
 <property name="Traits" value="Majin, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="0; 10,000; 20,000; 30,000; 90,000; 300,000; 600,000; 1,000,000; 1,500,000; 2,100,000; 2,700,000" />
+<property name="Power Rating" value="0; 10000; 20000; 30000; 90000; 300000; 600000; 1000000; 1500000; 2100000; 2700000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="3" />
 </card>
@@ -807,7 +807,7 @@
 <property name="Traits" value="Majin, Saiyan" />
 <property name="Limit per Deck" value="1" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="0; 1,000; 7,000; 15,000; 30,000; 60,000; 125,000; 375,000; 750,000; 1,500,000; 3,200,000" />
+<property name="Power Rating" value="0; 1000; 7000; 15000; 30000; 60000; 125000; 375000; 750000; 1500000; 3200000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="4" />
 </card>

--- a/sets/cf979d6f-712d-4b6e-bcd9-cafc6fcc5687/set.xml
+++ b/sets/cf979d6f-712d-4b6e-bcd9-cafc6fcc5687/set.xml
@@ -505,10 +505,10 @@
 <property name="Type" value="Hero Ally" />
 <property name="Endurance" value="" />
 <property name="Text" value="(Once per game, if your MP is Kid Trunks, you may play this card from your hand as an action to end combat.)  CONTINUOUS POWER: If your MP is Kid Trunks, your attacks deal +1 life card of damage." />
-<property name="Traits" value="" />
+<property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 150; 250; 500; 1000; 1500; 5000; 8000; 10000; 20000; 50000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="" />
 </card>
@@ -518,10 +518,10 @@
 <property name="Type" value="Hero Ally" />
 <property name="Endurance" value="" />
 <property name="Text" value="(If your MP is Goten, you may use this Power regardless of your MP's power stage.  INSTANT POWER: Use when entering combat.  Draw a card." />
-<property name="Traits" value="" />
+<property name="Traits" value="Earthling, Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 150; 250; 500; 1000; 2500; 5000; 7000; 10000; 30000; 60000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="" />
 </card>
@@ -531,10 +531,10 @@
 <property name="Type" value="Hero Ally" />
 <property name="Endurance" value="" />
 <property name="Text" value="(If your MP has EARTHLING, once per combat you may play this card from your hand as an action to gain 5 stages and draw a card.  CONTINUOUS POWER: If your MP has Earthling and 2 or less Traits, your opponent's attacks deal -2 stages of damage." />
-<property name="Traits" value="" />
+<property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 200; 600; 1000; 2000; 3000; 5000; 10000; 50000; 80000; 150000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="" />
 </card>
@@ -544,10 +544,10 @@
 <property name="Type" value="Hero/Villain Ally" />
 <property name="Endurance" value="" />
 <property name="Text" value="(Once per turn when this Ally enters play, you may Rejuvenate a Setup or Drill from your discard pile.)  CONTINUOUS POWER: After a player discards a card from their hand by a card effect, you may Rejuvenate 1.  (Created by Tommy Andred, OP2 TOP Champion.)" />
-<property name="Traits" value="" />
+<property name="Traits" value="God" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 199; 399; 599; 799; 999; 1199; 1399; 1599; 1799; 1999" />
 <property name="Rarity" value="Ultra Rare" />
 <property name="Card Level" value="" />
 </card>
@@ -557,10 +557,10 @@
 <property name="Type" value="Villain Ally" />
 <property name="Endurance" value="" />
 <property name="Text" value="(Bojack Only.  This card is considered Named and you may use these Powers regardless of your MP's power stage.)  INSTANT POWER: Use when this card is leaving play.  Banish it to use a critical damage effect.  POWER: Energy attack costing 2 stages.  DAMAGE: 2 life cards.  HIT: You may banish a Setup, Drill, Ally or attached card." />
-<property name="Traits" value="" />
+<property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 100; 300; 600; 1000; 5000; 9000; 25000; 50000; 100000; 500000" />
 <property name="Rarity" value="Uncommon" />
 <property name="Card Level" value="" />
 </card>
@@ -570,10 +570,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="POWER: Energy attack costing 2 stages.  Raise or lower a player's anger 1 level.  DAMAGE: 4 life cards.  HIT: Search your Life Deck for a Named Ally or Named Setup and play it." />
-<property name="Traits" value="" />
+<property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 1000; 2000; 5000; 7000; 10000; 30000; 50000; 100000; 300000; 800000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>
@@ -583,10 +583,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="INSTANT POWER: Use at the end of combat.  Destroy an Ally or Setup you control to Rejuvenate 4.  POWER: Energy attack costing 2 stages.  You may destroy a Named Ally or Named Setup you control.  If you do, damage from this attack cannot be prevented.  DAMAGE: 5 life cards.  HIT: Raise your anger 1 level.  Lower your opponent's anger 1 level." />
-<property name="Traits" value="" />
+<property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 1000; 3000; 10000; 30000; 70000; 100000; 200000; 600000; 1000000; 1250000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="2" />
 </card>
@@ -596,10 +596,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="(You cannot win by MPPV if you advance a level with this card's effect.)  INSTANT POWER: Use when entering combat.  Banish 'Team Bojack' you own in play to advance your MP 1 level.  POWER: Energy attack costing 2 stages.  Lower your opponent's anger 2 levels.  DAMAGE: 5 life cards.  HIT: Search your banished Zone for a Named card and Rejuvenate it." />
-<property name="Traits" value="" />
+<property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 5000; 10000; 25000; 50000; 90000; 150000; 400000; 700000; 1300000; 1700000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="3" />
 </card>
@@ -609,10 +609,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="CONTINUOUS POWER: Your energy attacks deal +2 life cards of damage.  POWER: Energy attack.  While you control a Named Ally or Named Setup, damage from this attack cannot be prevented.  DAMAAGE: 4 life cards.  HIT: Search your Life Deck or discard pile for a Named Ally or Named Setup and play it." />
-<property name="Traits" value="" />
+<property name="Traits" value="Alien" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 10000; 30000; 75000; 100000; 250000; 500000; 1000000; 1500000; 2000000; 2200000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="4" />
 </card>
@@ -622,10 +622,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="INSTANT POWER: Use after you Rejuvenate a Styled card during combat.  Raise your anger 2 levels.  POWER: Energy attack costing 2 stages.  You may reveal 2 attack cards from your hand to Rejuvenate 1.  DAMAGE: 3 life cards.  HIT: Rejuvenate 1." />
-<property name="Traits" value="" />
+<property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 500; 1350; 2500; 5000; 10000; 20000; 80000; 200000; 600000; 1000000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>
@@ -635,10 +635,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="CONTINUOUS POWER: Whenever you Rejuvenate during combat, gain 2 stages.  POWER: Rejuvenate 2.  You may reveal 2 attack cards from your hand to search your Life Deck for a Styled Setup or Styled Drill and place it into play." />
-<property name="Traits" value="" />
+<property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 1000; 5000; 15000; 25000; 40000; 50000; 100000; 400000; 800000; 1500000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="2" />
 </card>
@@ -648,10 +648,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal +2 life cards of damage.  INSTANT POWER: Use when you Rejuvenate during combat.  Use a critical damage effect.  POWER: Energy attack.  You may reveal 2 attacks from your hand to draw a card.  DAMAGE: 4 life cards." />
-<property name="Traits" value="" />
+<property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 20000; 50000; 70000; 100000; 250000; 500000; 700000; 1200000; 1700000; 2200000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="3" />
 </card>
@@ -661,10 +661,10 @@
 <property name="Type" value="Villain" />
 <property name="Endurance" value="" />
 <property name="Text" value="CONTINUOUS POWER: Your attacks deal +2 life cards of damage.  Whenever you Rejuvenate during combat, attacks if your next action this combat are considered to deal critical damage.  POWER: Energy attack.  Chosoe 3 cards in your discard pile and Rejuvenate them.  DAMAGE: 4 life cards.  HIT: Banish the top 10 cards of your opponent's discard pile." />
-<property name="Traits" value="" />
+<property name="Traits" value="Saiyan" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 10000; 30000; 75000; 150000; 300000; 600000; 900000; 1200000; 2200000; 3200000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="4" />
 </card>
@@ -674,10 +674,10 @@
 <property name="Type" value="Hero" />
 <property name="Endurance" value="" />
 <property name="Text" value="INSTANT POWER: Use when a 'when enter combat' effect isused.  Cancel that effect.  Banish the top card of your Life Deck.  POWER: Energy attack costing 1 stage.  DAMAGE: 2 life cards.  HIT: Search your discard pile or Banished Zone for a Named Card and Rejuvenate it." />
-<property name="Traits" value="" />
+<property name="Traits" value="Earthling" />
 <property name="Limit per Deck" value="" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="" />
+<property name="Power Rating" value="0; 1000; 2500; 5000; 10000; 15000; 30000; 60000; 90000; 120000; 150000" />
 <property name="Rarity" value="Starter" />
 <property name="Card Level" value="1" />
 </card>

--- a/sets/e8d510f7-4ad1-4ed8-a85d-3b7c21ce083b/set.xml
+++ b/sets/e8d510f7-4ad1-4ed8-a85d-3b7c21ce083b/set.xml
@@ -13,7 +13,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="1,000; 900; 800; 700; 600; 500; 400; 300; 200; 100; 0" />
+<property name="Power Rating" value="0; 100; 200; 300; 400; 500; 600; 700; 800; 900; 1000" />
 <property name="Text" value="(Heroes only.)  [CONSTANT]:  At the start of your Rejuvenation Step, place the top card of your discard pile at the bottom of your Life Deck.  When this card is leaving play, search your Life Deck for a Dragon Ball and place it into play." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -24,7 +24,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="1,200; 1,100; 1,000; 900; 800; 700; 600; 500; 250; 100; 0" />
+<property name="Power Rating" value="0; 100; 250; 500; 600; 700; 800; 900; 1000; 1100; 1200" />
 <property name="Text" value="(Heroes only.)  [CONSTANT]:  Players cannot use card effects to search a player's Life Deck." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -35,7 +35,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="50; 45; 40; 35; 30; 25; 20; 15; 10; 5; 0" />
+<property name="Power Rating" value="0; 5; 10; 15; 20; 25; 30; 35; 40; 45; 50" />
 <property name="Text" value="(Heroes only.)  [CONSTANT]:  Dragon Balls lose all effects." />
 <property name="Limit per Deck" value="3" />
 </card>
@@ -46,7 +46,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="400; 350; 300; 250; 200; 150; 100; 50; 25; 10; 0" />
+<property name="Power Rating" value="0; 10; 25; 50; 100; 150; 200; 250; 300; 350; 400" />
 <property name="Text" value="(Heroes only.)  [CONSTANT]:  Players cannot use Setups unless they have performed an attack from their hand this turn." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -57,7 +57,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="10; 9; 8; 7; 6; 5; 4; 3; 2; 1; 0" />
+<property name="Power Rating" value="0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10" />
 <property name="Text" value="(Villains only.)  POWER:  Banish Dr. Wheelo to choose an Ally, Drill, or Setup in play and shuffle that card into its owner's Life Deck." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -68,7 +68,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="400; 375; 350; 325; 300; 275; 250; 225; 200; 175; 0" />
+<property name="Power Rating" value="0; 175; 200; 225; 250; 275; 300; 325; 350; 375; 400" />
 <property name="Text" value="(Villains only.)  [CONSTANT]:  The first attack each player performs during combat cannot have its damage modified." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -79,7 +79,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="125,000; 75,000; 25,000; 20,000; 15,000; 10,000; 5,000; 4,000; 3,000; 2,000; 0" />
+<property name="Power Rating" value="0; 2000; 3000; 4000; 5000; 10000; 15000; 20000; 25000; 75000; 125000" />
 <property name="Text" value="(Villains only.)  POWER:  Place the top 3 Styled Events in your discard pile at the bottom of your Life Deck.  Shuffle 'Lord Slug' into your Life Deck." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -90,7 +90,7 @@
 <property name="Rarity" value="Common" />
 <property name="Type" value="Ally" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="100,000; 50,000; 25,000; 20,000; 15,000; 10,000; 5,000; 3,000; 1,000; 500; 0" />
+<property name="Power Rating" value="0; 500; 1000; 3000; 5000; 10000; 15000; 20000; 25000; 50000; 100000" />
 <property name="Text" value="(Villains only.)  [CONSTANT]:  If your MP is a Saiyan, your Styled attacks deal +X stages of damage.  X = the number of Saiyans in play." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1118,7 +1118,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="1" />
-<property name="Power Rating" value="10; 9; 8; 7; 6; 5; 4; 3; 2; 1; 0" />
+<property name="Power Rating" value="0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10" />
 <property name="Text" value="POWER:  Destroy the top card of your Life Deck to destroy the top 2 cards of your opponent's Life Deck.  Set your anger level to 3." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1129,7 +1129,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="1,000; 900; 800; 700; 600; 500; 400; 300; 200; 100; 0" />
+<property name="Power Rating" value="0; 100; 200; 300; 400; 500; 600; 700; 800; 900; 1000" />
 <property name="Text" value="[CONSTANT]:  Your attacks deal +2 life cards of damage.  Whenever you stop an attack, your opponent destroys the top card of his Life Deck." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1140,7 +1140,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="1,400; 1,350; 1,300; 1,250; 1,200; 1,150; 1,100; 1,000; 900; 800; 0" />
+<property name="Power Rating" value="0; 800; 900; 1000; 1100; 1150; 1200; 1250; 1300; 1350; 1400" />
 <property name="Text" value="[INSTANT] POWER:  Use after you perform a successful attack.  Destroy the top 2 cards of your opponent's Life Deck and Rejuveante 2.  [CONSTANT]:  Whenever one of your effects destroys cards from the top of your opponent's Life Deck, increase that amount by 1." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1151,7 +1151,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="2,600; 2,400; 2,200; 2,000; 1,800; 1,600; 1,400; 1,200; 1,000; 500, 0" />
+<property name="Power Rating" value="2600; 2400; 2200; 2000; 1800; 1600; 1400; 1200; 1000; 500, 0" />
 <property name="Text" value="[CONSTANT]:  Whenever one of your effects destroys cards from the top of your opponent's Life Deck, increase that amount by 2 and Rejuvenate 2." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1162,7 +1162,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="1,500; 1,300; 1,100; 900; 700; 500; 400; 300; 200; 100; 0" />
+<property name="Power Rating" value="0; 100; 200; 300; 400; 500; 700; 900; 1100; 1300; 1500" />
 <property name="Text" value="[CONSTANT]:  Your opponent's attacks deal -1 life card of damage.  You need 2 less anger to advance a personality level.  POWER:  Raise your anger 1 level." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1173,7 +1173,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="4,000; 3,500; 3,000; 2,500; 2,000; 1,500; 1,000; 750; 500; 250; 0" />
+<property name="Power Rating" value="0; 250; 500; 750; 1000; 1500; 2000; 2500; 3000; 3500; 4000" />
 <property name="Text" value="[CONSTANT]:  Your opponent's attacks deal -2 life cards of damage.  Whenever a Dragon Ball is revealed when taking damage, raise your anger 1 level." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1184,7 +1184,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="8,000; 7,000; 6,000; 5,000; 4,000; 3,000; 2,000; 1,000; 600; 300; 0" />
+<property name="Power Rating" value="0; 300; 600; 1000; 2000; 3000; 4000; 5000; 6000; 7000; 8000" />
 <property name="Text" value="[CONSTANT]:  Your opponent's attacks deal -2 life cards and -2 stages of damage.  Whenever you raise your anger, you may capture a Dragon Ball." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1195,7 +1195,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="25,000; 15,000; 10,000; 8,000; 6,000; 4,000; 2,000; 1,000; 500; 250; 0" />
+<property name="Power Rating" value="0; 250; 500; 1000; 2000; 4000; 6000; 8000; 10000; 15000; 25000" />
 <property name="Text" value="[CONSTANT]:  Your opponent's attacks deal +3 life cards of damage.  Your Dragon Balls cannot be captured.  Whenever your anger is lowered, you may capture a Dragon Ball." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1206,7 +1206,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="14,000; 12,000; 10,000; 8,000; 6,000; 4,000; 2,000; 1,000; 500; 250; 0" />
+<property name="Power Rating" value="0; 250; 500; 1000; 2000; 4000; 6000; 8000; 10000; 12000; 14000" />
 <property name="Text" value="[CONSTANT]:  Whenever a Dragon Ball enters play, raise your anger 1 level.  If you do not control a Dragon Ball at the end of combat, search your Life Deck for a Dragon Ball and place it into play." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1217,7 +1217,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="45,000; 40,000; 35,000; 30,000; 25,000; 20,000; 15,000; 10,000; 1,000; 500; 0" />
+<property name="Power Rating" value="0; 500; 1000; 10000; 15000; 20000; 25000; 30000; 35000; 40000; 45000" />
 <property name="Text" value="POWER:  Physical attack.  DAMAGE:  AT +3 stages.  HIT:  Rejuvenate 2." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1228,7 +1228,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="200,000; 150,000; 125,000; 100,000; 75,000; 50,000; 10,000; 1,000; 500; 250; 0" />
+<property name="Power Rating" value="0; 250; 500; 1000; 10000; 50000; 75000; 100000; 125000; 150000; 200000" />
 <property name="Text" value="[CONSTANT]:  Your attacks deal +2 stages of damage.  The first time during combat one of your effects shuffles or Rejuvenates cards from your discard pile into your Life Deck, double that amount." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1239,7 +1239,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="6" />
-<property name="Power Rating" value="400,000; 350,000; 300,000; 250,000; 200,000; 150,000; 100,000; 50,000; 10,000; 1,000; 0" />
+<property name="Power Rating" value="0; 1000; 10000; 50000; 100000; 150000; 200000; 250000; 300000; 350000; 400000" />
 <property name="Text" value="(You cannot win by MPPV)  [INSTANT] POWER:  Use when entering combat.  You may lower your MP 1 level or you may search your Life Deck for a Dragon Ball and play it." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1250,7 +1250,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="2" />
-<property name="Power Rating" value="12,000; 11,500; 11,000; 10,500; 10,000; 7,000; 4,000; 1,000; 500; 250; 0" />
+<property name="Power Rating" value="0; 250; 500; 1000; 4000; 7000; 10000; 10500; 11000; 11500; 12000" />
 <property name="Text" value="[CONSTANT]:  Your Styled attacks deal +2 stages of damage and cannot have their damage prevented." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1261,7 +1261,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="30,000; 25,000; 20,000; 15,000; 10,000; 8,000; 6,000; 4,000; 2,000; 1,000; 0" />
+<property name="Power Rating" value="0; 1000; 2000; 4000; 6000; 8000; 10000; 15000; 20000; 25000; 30000" />
 <property name="Text" value="POWER:  Energy attack costing 2 stages.  DAMAGE:  5 stages.  Damage from this cannot be prevented.  HIT:  Your opponent pays 3 stages or you may raise your anger 2 levels and use a critical damage effect." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1272,7 +1272,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="4" />
-<property name="Power Rating" value="125,000; 105,000; 85,000; 65,000; 45,000; 25,000; 20,000; 15,000; 10,000; 5,000; 0" />
+<property name="Power Rating" value="0; 5000; 10000; 15000; 20000; 25000; 45000; 65000; 85000; 105000; 125000" />
 <property name="Text" value="POWER:  Banish the top 3 cards of your opponent's discard pile.  [CONSTANT]:  Your attacks deal +3 stages of damage and cannot have their damage prevented." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1283,7 +1283,7 @@
 <property name="Rarity" value="Uncommon" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="5" />
-<property name="Power Rating" value="300,000; 200,000; 150,000; 100,000; 75,000; 50,000; 25,000; 20,000; 15,000; 10,000; 0" />
+<property name="Power Rating" value="0; 10000; 15000; 20000; 25000; 50000; 75000; 100000; 150000; 200000; 300000" />
 <property name="Text" value="POWER:  Physical attack.  DAMAGE:  X stages and X life cards.  X = the number of power stages your opponent's MP is above 0.  Endurance cannot be used this turn." />
 <property name="Limit per Deck" value="1" />
 </card>
@@ -1581,7 +1581,7 @@
 <property name="Rarity" value="Promo" />
 <property name="Type" value="Personality" />
 <property name="PUR" value="3" />
-<property name="Power Rating" value="150,000,000; 25,000,000; 1,250,000; 600,000; 300,000; 150,000; 75,000; 30,000;15,000; 7,500; 0" />
+<property name="Power Rating" value="150000000; 25000000; 1250000; 600000; 300000; 150000; 75000; 30000;15000; 7500; 0" />
 <property name="Text" value="(Villains only.)  [CONSTANT]:  If your MP is a Saiyan, your Styled attacks deal +X stages of damage.  X = the number of Saiyans in play." />
 <property name="Limit per Deck" value="1" />
 </card>


### PR DESCRIPTION
Development Notes

1.  Game Definition Updates:
    a. Added "engine" script file.
    b. Renamed old API event "OnLoadDeck" (which does nothing) to the current API event "OnDeckLoaded"
    c. Added events:
        1. OnGameStarted - sets numLoadedDecks variable to 0 (enables automatically putting MP/Mastery on the table).
        2. OnPhasePassed - handler for managing game phases
    d. Added "phases"
        1. icons are required, stole the sensei image for sideboards from the existing game files. At some point different images would be cool.
    e. Defined global var for numLoadedDecks (enables automatically putting MP/Mastery on the table).
    f. Placeholder function for performing AT lookups (needs a bit more fleshing out)
    g. Removed F* key shortcuts for printing phase messages to the chat window. (Replaced with actual OCTGN phases)
    h. Updated player variables
2. actions script updates:
    a. powerUp
        1. Prints a message that the calling player is powering up personalities
    b. faceUpAll
        1. New function that turns all cards owned by calling player face up (enables automatically putting MP/Mastery on the table).
    c. play
        1. Cards are now played on the calling player's side of the table instead of the same place no matter which player you are.
    d. drawThree
        1. New function for explicitly drawing 3 cards
    e. Removed functions related to old phase messaging system
3. constants script updates:
    a. Removed list of messages for old phase messaging system
    b. Added table coordinates for playing cards from hand and the inital MP/Mastery placement
4. events script updates:
    a. Added handlers for new events
    b. OnDeckLoaded changes
        1. This function wasn't doing anything in the current patch as the event name was wrong
        2. No longer try to put the OK/Wait/Actions? buttons on the table
        3. Automatically put MP/Mastery to the table (face down) when deck is loaded
        4. If both players have loaded their decks, MP/Mastery of both players will flip face up,
            MP will be set to 5 above 0, and choice for first player will be automatically determined
5. plugins script updates:
    a. Commented out a filename notify call to help clean up the chat window between turns
    b. Changed the autosave event handlers args to match what the function receives (it doesn't use the arguments in-function anyway)
    
    
Release Notes:

## Start of Game procedure updated ##
When you load your deck, your Level 1 MP and Mastery will automatically be placed on the table face down.
Once both players have loaded their decks, your cards will be flipped face up and OCTGN should put 5 counters
on your MP. OCTGN will pick a random player to choose which player will go first and that player will get a
dialog window to select the first player.
Note: If you use Saiyan Dynamic Mastery, your decision will technically be a little off-timing, as you'll make
your decision after you know which player is taking the first turn.

## Game Phases ##
The phase toolbar should appear on the right side of the screen. When it is your turn, advance from phase to
phase by pressing Ctrl+Enter. A description of the workflow:
- Opponent passes the turn to you.
- OCTGN runs the autosave functions
- Ctrl+Enter to start your draw phase. OCTGN will automatically draw your 3 cards for you.
- OCTGN will automatically enter your Planning Step and print a message describing the step.
- After you play Planning cards, press Ctrl+P to power up, and then Ctrl+Enter to open a declare combat dialog.
- Note: You will not be able to inspect discard piles, etc. while the dialog is open.
- If you Declared Combat, the "Entering Combat" phase will begin. Use any of your WEC effects, your opponent uses
   any of their WEC effects, and then your opponent should draw 3 cards (manually, with Ctrl+X, etc.)
- Ctrl+Enter will move to the "Combat" Phase.
- After combat is over and any End of Combat effects are used, Ctrl+Enter will move to the "Discard" phase.
- If you skipped combat, OCTGN will jump directly to the Discard Phase.
- After you each finish discarding cards, Ctrl+Enter to move to the Rejuvenate phase.
- If you did not declare combat, you'll get a dialog asking if you'd like to Rejuvenate 1.
- Note: If there are any "At the start of Rejuvenation Step" effects, you'll need to decline the dialog and manage those
   effects, and then rejuvenate manually.
- If you did declare combat and/or all "Rejuvenate Step" effects are complete, Ctrl+Enter will pass the turn to your opponent.

## Playing Cards

Double click a card from your hand and OCTGN will log it as played instead of moved to the table. Played cards now go to your own side of the table instead of always the same place for both players. 